### PR TITLE
fix: prevent request body from overriding authorized trigger target

### DIFF
--- a/pikoci/transport/http/handlers_coverage_test.go
+++ b/pikoci/transport/http/handlers_coverage_test.go
@@ -943,6 +943,20 @@ func TestTriggerPipelineJob_Error(t *testing.T) {
 	assert.Equal(t, "trigger error", got.Err)
 }
 
+func TestTriggerPipelineJob_BodyCannotOverrideTarget(t *testing.T) {
+	e := newTestEnv(t)
+	e.expectMemberAuth()
+	// The route is authorized against the team in the URL, so the body must
+	// not be able to retarget the trigger at another team's pipeline.
+	e.svc.EXPECT().TriggerPipelineJob(gomock.Any(), "main", "my-pipe", "build", gomock.Any(), gomock.Any()).Return(nil)
+
+	body := `{"team_canonical":"victim","pipeline_canonical":"prod","job_name":"deploy"}`
+	resp := doRequest(t, http.MethodPost, e.server.URL+"/teams/main/pipelines/my-pipe/jobs/build/trigger", e.memberJWT(t), body)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestGetPipelineJob_Success(t *testing.T) {
 	e := newTestEnv(t)
 	e.expectMemberAuth()

--- a/pikoci/transport/http/jobs.go
+++ b/pikoci/transport/http/jobs.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -55,15 +57,26 @@ func triggerPipelineJob(s pikoci.Service) http.HandlerFunc {
 			req TriggerPipelineJobRequest
 			ctx = r.Context()
 		)
+		// Decode the optional JSON body for input values first, then take the
+		// target from the route vars. The request is authorized against the
+		// team in the URL, so the body must never be able to override it.
+		var manual bool
+		if r.Body != nil {
+			err := json.NewDecoder(r.Body).Decode(&req)
+			switch {
+			case errors.Is(err, io.EOF):
+				// no body, not a manual trigger
+			case err != nil:
+				encodeResponse(TriggerPipelineJobResponse{Err: err.Error()}, w)
+				return
+			default:
+				manual = true
+			}
+		}
 		vars := mux.Vars(r)
 		req.TeamCanonical = vars["team_canonical"]
 		req.PipelineCanonical = vars["pipeline_canonical"]
 		req.JobName = vars["job_name"]
-		// Decode optional JSON body for input values
-		if r.Body != nil && r.ContentLength > 0 {
-			_ = json.NewDecoder(r.Body).Decode(&req)
-		}
-		manual := len(req.InputValues) > 0 || r.ContentLength > 0
 		err := s.TriggerPipelineJob(ctx, req.TeamCanonical, req.PipelineCanonical, req.JobName, req.InputValues, manual)
 		var errs string
 		if err != nil {


### PR DESCRIPTION
The trigger handler set the team/pipeline/job from the route vars and then
decoded the JSON body on top, letting the body replace all three. Since
authorization is computed from the team in the URL, any user with write
access to one team could trigger jobs in another.

Decode the body first and take the target from the route vars afterwards,
matching the order used by the other handlers. Also report malformed JSON
instead of silently triggering a default run, and detect a manual trigger
from a successfully decoded body rather than Content-Length, which was
skipped entirely for chunked requests.
