### PR TITLE
fix: make job declaration order deterministic and reject colliding for_each names

### DIFF
--- a/pikoci/for_each_test.go
+++ b/pikoci/for_each_test.go
@@ -318,6 +318,35 @@ job "test" {
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
+func TestCreatePipeline_ForEachNameCollision(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	hclConfig := []byte(`
+resource "cron" "tick" {
+  check_interval = "@every 1m"
+}
+
+job "build--linux" {
+  get "cron" "tick" {
+    trigger = true
+  }
+}
+
+job "build" {
+  for_each = toset(["linux", "mac"])
+  get "cron" "tick" {
+    trigger = true
+  }
+}
+`)
+
+	_, err := s.S.CreatePipeline(ctx, "main", "my-pipe", hclConfig, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already used by another job")
+}
+
 func TestCreatePipeline_ForEachEmptySet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	s := newService(ctrl)

--- a/pikoci/helper.go
+++ b/pikoci/helper.go
@@ -1161,6 +1161,13 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 	}
 	forEachMetas := make(map[string]forEachJobMeta)
 	cleanedForEachBlocks := make(map[string][]byte) // cache cleaned blocks per base name
+	// Expansion names must not collide with an already declared job, otherwise
+	// the pipeline ends up with two jobs of the same name and the reordering
+	// below cannot tell them apart.
+	declaredJobNames := make(map[string]bool, len(hp.Jobs))
+	for _, hj := range hp.Jobs {
+		declaredJobNames[hj.Name] = true
+	}
 	for _, exp := range forEachExpansions {
 		blockRaw := forEachBlockBytes[exp.baseName]
 		cleanBlock, cErr := removeForEachAndMatrixFromBlock(blockRaw)
@@ -1182,6 +1189,10 @@ func ReadPipeline(ctx context.Context, rpp []byte, vars map[string]interface{}) 
 			}
 			expandedJob := singleJobFile.Jobs[0]
 			expandedJob.Name = exp.baseName + "--" + inst.slugKey
+			if declaredJobNames[expandedJob.Name] {
+				return nil, fmt.Errorf("for_each instance %q of job %q expands to job name %q, which is already used by another job", inst.key, exp.baseName, expandedJob.Name)
+			}
+			declaredJobNames[expandedJob.Name] = true
 			hp.Jobs = append(hp.Jobs, expandedJob)
 			forEachMetas[expandedJob.Name] = forEachJobMeta{
 				baseName: exp.baseName,

--- a/pikoci/mysql/job.go
+++ b/pikoci/mysql/job.go
@@ -240,7 +240,7 @@ func (r *JobRepository) Filter(ctx context.Context, tc, pn string) ([]*job.Job, 
 		JOIN teams AS t
 			ON p.team_id = t.id
 		WHERE t.canonical = ? AND p.canonical = ?
-		ORDER BY j.`+"`order`"+` ASC
+		ORDER BY j.`+"`order`"+` ASC, j.id ASC
 	`, tc, pn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter jobs: %w", err)
@@ -486,7 +486,7 @@ func (r *JobRepository) FilterByForEachGroup(ctx context.Context, tc, pn, group 
 		JOIN teams AS t
 			ON p.team_id = t.id
 		WHERE t.canonical = ? AND p.canonical = ? AND j.for_each_group = ?
-		ORDER BY j.`+"`order`"+` ASC
+		ORDER BY j.`+"`order`"+` ASC, j.id ASC
 	`, tc, pn, group)
 	if err != nil {
 		return nil, fmt.Errorf("failed to filter jobs by for_each group: %w", err)

--- a/pikoci/mysql/pipeline.go
+++ b/pikoci/mysql/pipeline.go
@@ -318,7 +318,7 @@ func scanPipelinesWithTeam(rows *sql.Rows) ([]*pipeline.WithTeam, error) {
 	result := make([]*pipeline.WithTeam, 0, len(pipelineOrder))
 	for _, id := range pipelineOrder {
 		p := pipelineMap[id]
-		sort.Slice(p.Jobs, func(i, j int) bool { return p.Jobs[i].Order < p.Jobs[j].Order })
+		sort.SliceStable(p.Jobs, func(i, j int) bool { return p.Jobs[i].Order < p.Jobs[j].Order })
 		result = append(result, p)
 	}
 	return result, nil
@@ -475,7 +475,7 @@ func scanPipelines(rows *sql.Rows) ([]*pipeline.Pipeline, error) {
 	result := make([]*pipeline.Pipeline, 0, len(pipelineOrder))
 	for _, id := range pipelineOrder {
 		p := pipelineMap[id]
-		sort.Slice(p.Jobs, func(i, j int) bool { return p.Jobs[i].Order < p.Jobs[j].Order })
+		sort.SliceStable(p.Jobs, func(i, j int) bool { return p.Jobs[i].Order < p.Jobs[j].Order })
 		result = append(result, p)
 	}
 	return result, nil


### PR DESCRIPTION
- **fix: reject for_each expansions that collide with a declared job name**
- **fix: give job ordering a deterministic tiebreaker**
