### PR TITLE
chore: run tests with the race detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,23 +71,23 @@ test: test-mock test-http test-js test-integration test-backends ## Runs all tes
 
 .PHONY: test-mock
 test-mock: ## Runs unit/mock tests (no services needed)
-	go test ./... -v -timeout 120s -coverprofile=coverage.out
+	go test -race ./... -v -timeout 300s -coverprofile=coverage.out
 
 .PHONY: test-http
 test-http: ## Runs HTTP API integration tests (no browser needed)
-	go test -tags integration ./integration/http/... -v
+	go test -race -tags integration ./integration/http/... -v
 
 .PHONY: test-integration
 test-integration: ## Runs UI and backend integration tests (requires geckodriver + Xvfb + Firefox)
 	@PIKOCI_TEST_DB_SYSTEMS=$${PIKOCI_TEST_DB_SYSTEMS:-mem,sqlite} \
-	go test -tags integration ./integration/selenium/ -v
+	go test -race -tags integration ./integration/selenium/ -v
 
 .PHONY: test-backends
 test-backends: ## Runs integration tests with all backends (requires test-services-up)
 	@PIKOCI_TEST_DB_SYSTEMS=mem,sqlite,mysql,postgresql \
 	PIKOCI_TEST_VAULT=1 \
 	PIKOCI_TEST_VAULT_ADDR=http://127.0.0.1:8200 \
-	go test -tags integration ./integration/backends/... -v -coverprofile=coverage-backends.out
+	go test -race -tags integration ./integration/backends/... -v -coverprofile=coverage-backends.out
 
 .PHONY: test-js
 test-js: ## Run JavaScript unit tests


### PR DESCRIPTION
The unit and integration test targets ran without -race, so a data race
in the worker or scheduler would only ever show up as a flake.

Enable it on all four go test targets. The full suite takes about twice
as long (2m instead of 1m here), so test-mock's per-binary timeout goes
from 120s to 300s; the slowest package currently sits at 115s under
-race.
