### PR TITLE
fix: concurrency cleanups from a review pass

### DIFF
--- a/pikoci/grpc/server.go
+++ b/pikoci/grpc/server.go
@@ -173,26 +173,46 @@ func (s *Server) Execute(stream workerv1.WorkerService_ExecuteServer) error {
 	// Goroutine: listen for notifier signals and dispatch work
 	go s.dispatchLoop(ctx, ws)
 
-	// Main loop: receive messages from the worker
+	// Recv blocks until the worker says something, so it runs separately
+	// from the loop below, which must also react to send failures. It exits
+	// when the handler returns and ends the RPC.
+	type recvResult struct {
+		msg *workerv1.WorkerMessage
+		err error
+	}
+	recvCh := make(chan recvResult)
+	go func() {
+		for {
+			msg, err := stream.Recv()
+			select {
+			case recvCh <- recvResult{msg: msg, err: err}:
+			case <-ctx.Done():
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
 		case err := <-sendErr:
 			s.logger.Error("send error on worker stream", "worker_id", workerID, "error", err)
 			return err
-		default:
+		case <-ctx.Done():
+			return ctx.Err()
+		case r := <-recvCh:
+			if r.err == io.EOF {
+				s.logger.Info("worker disconnected", "worker_id", workerID)
+				return nil
+			}
+			if r.err != nil {
+				s.logger.Error("recv error on worker stream", "worker_id", workerID, "error", r.err)
+				return r.err
+			}
+			s.handleWorkerMessage(ctx, ws, r.msg)
 		}
-
-		msg, err := stream.Recv()
-		if err == io.EOF {
-			s.logger.Info("worker disconnected", "worker_id", workerID)
-			return nil
-		}
-		if err != nil {
-			s.logger.Error("recv error on worker stream", "worker_id", workerID, "error", err)
-			return err
-		}
-
-		s.handleWorkerMessage(ctx, ws, msg)
 	}
 }
 
@@ -400,4 +420,3 @@ func (s *Server) validateWorkerToken(ctx context.Context, tokenStr string) (stri
 
 	return tc, nil
 }
-

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -60,6 +60,10 @@ var publicFallbackRoutes = map[RouteName]bool{
 func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, version, commit, externalURL string, stateStore *pikoci.OAuthStateStore) http.Handler {
 	r := mux.NewRouter()
 
+	// Bounds the "API token last used" writes: without a cap, every
+	// token-authenticated request spawns its own goroutine and DB write.
+	lastUsedSlots := make(chan struct{}, 8)
+
 	auth := func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, rr *http.Request) {
 			// Determine route name early for public fallback check
@@ -107,7 +111,18 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 						rr = rr.WithContext(context.WithValue(rr.Context(), UsernameContextKey, un))
 						rr = rr.WithContext(context.WithValue(rr.Context(), pikoci.ActorContextKey, un))
 						rr = rr.WithContext(context.WithValue(rr.Context(), ApiTokenContextKey, authResult))
-						go s.UpdateApiTokenLastUsed(context.Background(), authResult.TokenID)
+						// last_used is advisory, so dropping an update
+						// under load is better than queueing it.
+						select {
+						case lastUsedSlots <- struct{}{}:
+							updCtx := context.WithoutCancel(rr.Context())
+							tokenID := authResult.TokenID
+							go func() {
+								defer func() { <-lastUsedSlots }()
+								s.UpdateApiTokenLastUsed(updCtx, tokenID)
+							}()
+						default:
+						}
 					}
 				} else {
 					// JWT auth

--- a/worker/grpc_client.go
+++ b/worker/grpc_client.go
@@ -79,17 +79,6 @@ func (w *Worker) grpcSession(ctx context.Context) error {
 		return fmt.Errorf("failed to send initial heartbeat: %w", err)
 	}
 
-	// Store stream atomically for use by job handlers
-	w.grpcStreamMu.Lock()
-	w.grpcStream = stream
-	w.grpcStreamMu.Unlock()
-
-	defer func() {
-		w.grpcStreamMu.Lock()
-		w.grpcStream = nil
-		w.grpcStreamMu.Unlock()
-	}()
-
 	// Start heartbeat sender
 	go w.grpcHeartbeatLoop(ctx, stream)
 

--- a/worker/service.go
+++ b/worker/service.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pikoci/pikoci/pikoci/build"
 	"github.com/pikoci/pikoci/pikoci/job"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
-	"github.com/pikoci/pikoci/pikoci/workitem"
 	"github.com/pikoci/pikoci/pikoci/resource"
 	"github.com/pikoci/pikoci/pikoci/restype"
 	"github.com/pikoci/pikoci/pikoci/runner"
@@ -38,6 +37,7 @@ import (
 	"github.com/pikoci/pikoci/pikoci/service"
 	"github.com/pikoci/pikoci/pikoci/utils"
 	"github.com/pikoci/pikoci/pikoci/wkr"
+	"github.com/pikoci/pikoci/pikoci/workitem"
 	"gopkg.in/yaml.v3"
 )
 
@@ -59,13 +59,13 @@ type WorkPoller interface {
 // polling or gRPC streaming. It manages build lifecycle, executes pipeline
 // steps, and supports graceful draining.
 type Worker struct {
-	pikoci            pikoci.Service
-	workPoller        WorkPoller
+	pikoci     pikoci.Service
+	workPoller WorkPoller
 
 	draining      atomic.Bool
 	drainCancelMu sync.Mutex
 	drainCancel   context.CancelFunc
-	logger      *slog.Logger
+	logger        *slog.Logger
 
 	// apiCtx is the parent server context used for DB operations.
 	// It outlives individual job contexts (which get cancelled on
@@ -3188,7 +3188,17 @@ func (w *Worker) waitForServices(ctx context.Context, m workitem.Body, b *build.
 					}
 					return
 				}
-				time.Sleep(interval)
+				select {
+				case <-time.After(interval):
+				case <-ctx.Done():
+					results <- readyResult{
+						name: svcName,
+						out:  lastOut,
+						d:    time.Since(start),
+						err:  ctx.Err(),
+					}
+					return
+				}
 			}
 		}(ss.Name, *svc.ReadyCheck, ru, readyRC, ss.Params)
 	}

--- a/worker/service.go
+++ b/worker/service.go
@@ -98,12 +98,8 @@ type Worker struct {
 
 	// grpcClient is the gRPC client for the WorkerService.
 	grpcClient workerv1.WorkerServiceClient
-	// grpcStream is the active Execute stream (nil when not connected).
-	// Protected by grpcStreamMu.
-	grpcStreamMu sync.Mutex
-	grpcStream   workerv1.WorkerService_ExecuteClient
-
 	// jobCancels tracks active job cancel functions for gRPC cancellation.
+	// Created on first use so the zero value of Worker stays usable.
 	jobCancelsMu sync.Mutex
 	jobCancels   map[string]context.CancelFunc
 }
@@ -272,7 +268,6 @@ func (w *Worker) Run(ctx context.Context) error {
 	defer receiveCancel()
 
 	if w.GRPCAddr != "" {
-		w.jobCancels = make(map[string]context.CancelFunc)
 		return w.grpcLoop(receiveCtx)
 	}
 
@@ -3526,18 +3521,17 @@ func isDuplicateKeyError(err error) bool {
 // trackJob records a cancel function for a running job (used by gRPC mode).
 func (w *Worker) trackJob(buildID string, cancel context.CancelFunc) {
 	w.jobCancelsMu.Lock()
-	if w.jobCancels != nil {
-		w.jobCancels[buildID] = cancel
+	defer w.jobCancelsMu.Unlock()
+	if w.jobCancels == nil {
+		w.jobCancels = make(map[string]context.CancelFunc)
 	}
-	w.jobCancelsMu.Unlock()
+	w.jobCancels[buildID] = cancel
 }
 
 // untrackJob removes a job's cancel function.
 func (w *Worker) untrackJob(buildID string) {
 	w.jobCancelsMu.Lock()
-	if w.jobCancels != nil {
-		delete(w.jobCancels, buildID)
-	}
+	delete(w.jobCancels, buildID)
 	w.jobCancelsMu.Unlock()
 }
 
@@ -3555,8 +3549,5 @@ func (w *Worker) cancelJob(buildID string) {
 func (w *Worker) activeJobCount() int {
 	w.jobCancelsMu.Lock()
 	defer w.jobCancelsMu.Unlock()
-	if w.jobCancels == nil {
-		return 0
-	}
 	return len(w.jobCancels)
 }


### PR DESCRIPTION
- **fix: stop sleeping through cancellation in ready_check**
- **fix: tidy up job cancel tracking and drop unused stream field**
- **fix: bound the API token last-used updates**
- **fix: react to worker stream send errors without waiting for a recv**
