### PR TITLE
fix: pass status filter in checkPassedConstraints to get builds with steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`passed` constraint infinite trigger loop**: `checkPassedConstraints` now requests only `succeeded`/`warning` builds, which forces the server to return full step data. Without the status filter the HTTP endpoint returned builds without steps (summary optimisation), making the version intersection always empty — every triggered build was immediately deleted and re-triggered ([#656](https://github.com/PikoCI/pikoci/issues/656)).
 - **Build list tabs show stale status**: Build tabs no longer stay stuck on "running" after a build completes — they now refresh automatically when a non-terminal build transitions to a terminal state.
 - **Trigger handler authorization bypass**: JSON body could override route vars to trigger jobs in unauthorized teams; body is now decoded before route vars are applied ([#644](https://github.com/PikoCI/pikoci/issues/644)).
 - **Active build data overwritten by stale snapshot**: The `onFullBuildFetched` callback now merges only enrichment fields (steps, approvals, version_metadata, pinned_versions) into the polling state rather than replacing the entire build object.

--- a/worker/service.go
+++ b/worker/service.go
@@ -603,7 +603,11 @@ func (w *Worker) checkPassedConstraints(ctx context.Context, m workitem.Body, b 
 		var intersection map[uint32]bool
 		var hasSucceeded bool
 		for _, p := range expandedPassed {
-			builds, _, err := w.pikoci.ListJobBuilds(ctx, m.TeamCanonical, m.PipelineCanonical, p, nil, nil, 0, nil)
+			// Request only succeeded/warning builds so the HTTP layer returns
+			// full step data (the summary optimisation omits steps when no
+			// status filter is present, which would break version matching).
+			passedStatuses := []build.Status{build.Succeeded, build.Warning}
+			builds, _, err := w.pikoci.ListJobBuilds(ctx, m.TeamCanonical, m.PipelineCanonical, p, nil, nil, 0, passedStatuses)
 			if err != nil {
 				w.failBuild(ctx, m, *b, fmt.Errorf("failed to list builds for passed job %q: %w", p, err))
 				return false, nil

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -391,7 +391,7 @@ func TestProcessJob_FailedPassedConstraint_NoBuilds(t *testing.T) {
 		Return(&pp.Jobs[0], nil)
 
 	// Passed check: upstream-job has no builds
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{}, false, nil)
 
 	// Build should be deleted (not failed)
@@ -442,7 +442,7 @@ func TestProcessJob_FailedPassedConstraint_NotSucceeded(t *testing.T) {
 		Return(&pp.Jobs[0], nil)
 
 	// Passed check: upstream-job has a failed build
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{{ID: 5, Status: build.Failed}}, false, nil)
 
 	// Build should be deleted
@@ -518,7 +518,7 @@ func TestProcessJob_PassedConstraint_AcceptsWarningBuilds(t *testing.T) {
 		Return(&pp.Jobs[0], nil)
 
 	// Upstream job has a WARNING build (from allow_failure) — should be treated as success
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{{
 			ID:     5,
 			Status: build.Warning,
@@ -1100,11 +1100,11 @@ func TestCheckPassedConstraints_AllPassed(t *testing.T) {
 		},
 	}
 
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-a", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-a", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{{ID: 1, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-cron", VersionID: 5},
 		}}}, false, nil)
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-b", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "job-b", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{{ID: 2, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-cron", VersionID: 5},
 		}}}, false, nil)
@@ -1141,11 +1141,11 @@ func TestCheckPassedConstraints_NoCommonVersion(t *testing.T) {
 	}
 
 	// lint succeeded with version 5, test succeeded with version 6
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{{ID: 10, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-repo", VersionID: 5},
 		}}}, false, nil)
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{{ID: 11, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "get", Name: "my-repo", VersionID: 6},
 		}}}, false, nil)
@@ -1186,7 +1186,7 @@ func TestCheckPassedConstraints_PicksNewestCommon(t *testing.T) {
 	}
 
 	// lint has builds with versions {3, 5}
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "lint", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{
 			{ID: 10, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 5},
@@ -1196,7 +1196,7 @@ func TestCheckPassedConstraints_PicksNewestCommon(t *testing.T) {
 			}},
 		}, false, nil)
 	// test has builds with versions {5, 7}
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "test", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{
 			{ID: 12, Status: build.Succeeded, Steps: []build.Step{
 				{Type: "get", Name: "my-repo", VersionID: 7},
@@ -1268,7 +1268,7 @@ func TestCheckPassedConstraints_PutStepSatisfiesPassed(t *testing.T) {
 	}
 
 	// The upstream job has a put step (not a get step) with the version
-	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), ([]build.Status)(nil)).
+	svc.EXPECT().ListJobBuilds(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "upstream-job", (*uint32)(nil), (*uint32)(nil), uint32(0), []build.Status{build.Succeeded, build.Warning}).
 		Return([]*build.Build{{ID: 1, Status: build.Succeeded, Steps: []build.Step{
 			{Type: "put", Name: "my-artifact", VersionID: 7},
 		}}}, false, nil)
@@ -1276,6 +1276,55 @@ func TestCheckPassedConstraints_PutStepSatisfiesPassed(t *testing.T) {
 	ok, resolved := w.checkPassedConstraints(ctx, m, &b, j, nil)
 	assert.True(t, ok)
 	assert.Equal(t, map[string]uint32{"artifact.my-artifact": 7}, resolved)
+}
+
+func TestCheckPassedConstraints_RequestsSucceededAndWarningStatuses(t *testing.T) {
+	// Regression test: ListJobBuilds must be called with succeeded+warning
+	// status filters so the HTTP layer returns full step data. Without the
+	// filter the server omits steps (summary optimisation), which causes
+	// checkPassedConstraints to find no version IDs and delete the build,
+	// triggering an infinite retry loop.
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "downstream",
+		BuildID:           99,
+	}
+	b := build.Build{ID: 99, BuildNumber: "1"}
+	j := &job.Job{
+		Name: "downstream",
+		Plan: []job.PlanStep{
+			{
+				Type: job.StepTypeGet,
+				Get: &job.GetStep{
+					Type:    "git",
+					Name:    "app",
+					Passed:  []string{"upstream"},
+					Trigger: true,
+				},
+			},
+		},
+	}
+
+	// The mock must receive exactly succeeded+warning statuses — not nil.
+	svc.EXPECT().ListJobBuilds(
+		gomock.Any(),
+		m.TeamCanonical, m.PipelineCanonical, "upstream",
+		(*uint32)(nil), (*uint32)(nil), uint32(0),
+		[]build.Status{build.Succeeded, build.Warning},
+	).Return([]*build.Build{{
+		ID:     1,
+		Status: build.Succeeded,
+		Steps:  []build.Step{{Type: "get", Name: "app", VersionID: 42}},
+	}}, false, nil)
+
+	ok, resolved := w.checkPassedConstraints(ctx, m, &b, j, nil)
+	assert.True(t, ok)
+	assert.Equal(t, map[string]uint32{"git.app": 42}, resolved)
 }
 
 func TestImplicitGetAfterPut_CreatesVersionAndRecords(t *testing.T) {


### PR DESCRIPTION
- Pass `succeeded`+`warning` status filter when calling `ListJobBuilds` in `checkPassedConstraints`
- Update existing test expectations to expect the status filter
- Add `TestCheckPassedConstraints_RequestsSucceededAndWarningStatuses` as a regression test

## Root cause

Since #653, the `ListJobBuilds` HTTP endpoint returns builds without step data when no status filter is present (summary optimisation for list views). The worker calls this endpoint via the HTTP client with no status filter, so `checkPassedConstraints` receives builds with empty steps. With no step data, the resource-version intersection is always empty → "no common version across passed jobs" → build is deleted → server re-triggers → infinite loop.

The `test-backends` job has been stuck in this loop since the deploy of that commit.

Closes #656