### PR TITLE
feat: show live elapsed time on currently running steps (#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Running step elapsed time not shown**: Steps currently in progress now display a live-updating elapsed timer (matching the format of completed steps), consistent with the global build timer already shown at the top of the page ([#655](https://github.com/PikoCI/pikoci/issues/655)).
 - **Services inside `if` branches not stopped**: services started within an `if` branch are now returned to the plan runner and stopped correctly, even when the branch fails ([#664](https://github.com/PikoCI/pikoci/issues/664)).
 - **Consecutive `if` blocks merged into one chain**: a second `if` block now starts an independent conditional chain; previously it was treated as a continuation, causing `else`/`else_if` blocks to attach to the wrong `if` ([#664](https://github.com/PikoCI/pikoci/issues/664)).
 - **Condition variable injection**: `$VAR` references are now substituted after the expression is parsed, so a value containing spaces, quotes or operator characters cannot alter the condition logic; malformed conditions (e.g. unsupported operators) are now rejected at pipeline-save time instead of failing at build runtime ([#662](https://github.com/PikoCI/pikoci/issues/662)).

--- a/pikoci/build/build.go
+++ b/pikoci/build/build.go
@@ -123,5 +123,6 @@ type Step struct {
 	Logs      string        `json:"logs"`
 	Duration  time.Duration `json:"duration"`
 	Status    Status        `json:"status"`
+	StartedAt *time.Time    `json:"started_at,omitempty"`
 	SubSteps  []Step        `json:"sub_steps,omitempty"`
 }

--- a/pikoci/transport/http/assets/js/app/components/Jobs.js
+++ b/pikoci/transport/http/assets/js/app/components/Jobs.js
@@ -49,18 +49,21 @@ function buildStatusBadge(status) {
   return null;
 }
 
+// Prepare a step's duration field for display (nanoseconds -> string), recursing into sub_steps.
+function prepareStep(s) {
+  const step = { ...s, duration: durationToString(s.duration) };
+  if (s.sub_steps) {
+    step.sub_steps = s.sub_steps.map(prepareStep);
+  }
+  return step;
+}
+
 // Prepare a build's duration fields for display (nanoseconds -> string)
 function prepareBuild(b) {
   if (!b) return b;
   const out = { ...b };
   out.duration = b.duration !== 0 ? durationToString(b.duration) : 0;
-  out.steps = (b.steps || []).map(s => {
-    const step = { ...s, duration: durationToString(s.duration) };
-    if (s.sub_steps) {
-      step.sub_steps = s.sub_steps.map(c => ({ ...c, duration: durationToString(c.duration) }));
-    }
-    return step;
-  });
+  out.steps = (b.steps || []).map(prepareStep);
   out.job = (b.job || []).map(j => ({ ...j, duration: durationToString(j.duration) }));
   return out;
 }
@@ -82,7 +85,7 @@ function BuildTab({ build, active, onClick }) {
 
 // ---------- StepRow ----------
 
-function StepRow({ step, expanded, onToggle, autoFollow, setAutoFollow, isAutoScrollingRef }) {
+export function StepRow({ step, expanded, onToggle, autoFollow, setAutoFollow, isAutoScrollingRef, stepElapsed }) {
   const preRef = useRef(null);
   const logs = processLogs(step.logs);
 
@@ -125,7 +128,10 @@ function StepRow({ step, expanded, onToggle, autoFollow, setAutoFollow, isAutoSc
         <span>
           <span class="piko-step-label"><i class="bi ${getStepIcon(step.type)}"></i> ${step.type || 'step'}</span>
           ${' '}${step.name}${' '}
-          <span style="color:var(--text-muted);">(${step.duration})</span>
+          ${stepElapsed && stepElapsed[step.name]
+            ? html`<span style="color:var(--text-muted);">(${stepElapsed[step.name]})</span>`
+            : html`<span style="color:var(--text-muted);">(${step.duration})</span>`
+          }
         </span>
         <span style="display:flex;align-items:center;gap:6px;">
           ${step.logs ? html`
@@ -173,7 +179,7 @@ function InputStep({ inputValues, expanded, onToggle }) {
 
 // ---------- ParallelGroup ----------
 
-function ParallelGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoFollow, setAutoFollow, isAutoScrollingRef }) {
+function ParallelGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoFollow, setAutoFollow, isAutoScrollingRef, stepElapsed }) {
   const [groupExpanded, setGroupExpanded] = useState(true);
 
   return html`
@@ -198,6 +204,7 @@ function ParallelGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoF
             autoFollow=${autoFollow}
             setAutoFollow=${setAutoFollow}
             isAutoScrollingRef=${isAutoScrollingRef}
+            stepElapsed=${stepElapsed}
           />
         `)}
       </div>
@@ -207,7 +214,7 @@ function ParallelGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoF
 
 // ---------- ConditionalGroup ----------
 
-function ConditionalGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoFollow, setAutoFollow, isAutoScrollingRef }) {
+function ConditionalGroup({ step, expandedSteps, onToggleStep, stepIndexBase, autoFollow, setAutoFollow, isAutoScrollingRef, stepElapsed }) {
   const [groupExpanded, setGroupExpanded] = useState(true);
   const branches = step.sub_steps || [];
   const entered = branches.find(b => b.status !== 'skipped');
@@ -251,6 +258,7 @@ function ConditionalGroup({ step, expandedSteps, onToggleStep, stepIndexBase, au
                       autoFollow=${autoFollow}
                       setAutoFollow=${setAutoFollow}
                       isAutoScrollingRef=${isAutoScrollingRef}
+                      stepElapsed=${stepElapsed}
                     />
                   `)}
                 </div>
@@ -332,6 +340,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry, onFu
   const [expandedSteps, setExpandedSteps] = useState({});
   const [elapsed, setElapsed] = useState('');
   const [timeAgo, setTimeAgo] = useState('');
+  const [stepElapsed, setStepElapsed] = useState({});
   const isAutoScrollingRef = useRef(false);
   const [cancelLoading, withCancelLoading] = useLoading();
   const [retryLoading, withRetryLoading] = useLoading();
@@ -385,6 +394,19 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry, onFu
     }
   }, [build]);
 
+  // Keep a ref to the most recently available steps so the interval always reads
+  // non-null data. We only update the ref when we have real steps (i.e. from the
+  // status-filtered poll or from the full-build fetch), so the elapsed keeps
+  // computing between polls even when the next render's rawBuild.steps is null.
+  const latestStepsRef = useRef(null);
+  if (rawBuild.steps) {
+    latestStepsRef.current = rawBuild.steps;
+  }
+
+  // Client-side fallback: record the first time we observe each step as 'started'.
+  // Used when the backend hasn't set started_at (e.g. older server versions).
+  const stepFirstSeenRef = useRef({});
+
   // Elapsed timer
   useEffect(() => {
     if (!build) return;
@@ -403,6 +425,25 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry, onFu
       if (rawBuild.started_at) {
         setTimeAgo(pikoTimeAgo(rawBuild.started_at));
       }
+      // Per-step elapsed: use server started_at when available, otherwise fall
+      // back to the first time the browser saw this step in 'started' state.
+      const newStepElapsed = {};
+      const computeStepElapsed = (steps) => {
+        for (const s of (steps || [])) {
+          if (s.status === 'started') {
+            const serverTs = s.started_at ? new Date(s.started_at).getTime() : null;
+            if (!stepFirstSeenRef.current[s.name]) {
+              stepFirstSeenRef.current[s.name] = serverTs || Date.now();
+            }
+            const startMs = serverTs || stepFirstSeenRef.current[s.name];
+            const secs = Math.floor((Date.now() - startMs) / 1000);
+            newStepElapsed[s.name] = durationToString(secs * 1e9);
+          }
+          if (s.sub_steps) computeStepElapsed(s.sub_steps);
+        }
+      };
+      computeStepElapsed(latestStepsRef.current);
+      setStepElapsed(newStepElapsed);
     };
     update();
     const id = setInterval(() => {
@@ -619,6 +660,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry, onFu
               autoFollow=${autoFollow}
               setAutoFollow=${setAutoFollow}
               isAutoScrollingRef=${isAutoScrollingRef}
+              stepElapsed=${stepElapsed}
             />
           `;
         }
@@ -633,6 +675,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry, onFu
               autoFollow=${autoFollow}
               setAutoFollow=${setAutoFollow}
               isAutoScrollingRef=${isAutoScrollingRef}
+              stepElapsed=${stepElapsed}
             />
           `;
         }
@@ -645,6 +688,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry, onFu
             autoFollow=${autoFollow}
             setAutoFollow=${setAutoFollow}
             isAutoScrollingRef=${isAutoScrollingRef}
+            stepElapsed=${stepElapsed}
           />
         `;
       })}
@@ -657,6 +701,7 @@ function BuildContent({ build: rawBuild, tc, pn, jn, job: jobData, onRetry, onFu
           autoFollow=${autoFollow}
           setAutoFollow=${setAutoFollow}
           isAutoScrollingRef=${isAutoScrollingRef}
+          stepElapsed=${stepElapsed}
         />
       `)}
     </div>

--- a/test/js/components.test.mjs
+++ b/test/js/components.test.mjs
@@ -5,6 +5,7 @@ import { html } from 'htm/preact';
 
 import { Login } from '../../pikoci/transport/http/assets/js/app/components/Login.js';
 import { Breadcrumb } from '../../pikoci/transport/http/assets/js/app/components/Layout.js';
+import { StepRow } from '../../pikoci/transport/http/assets/js/app/components/Jobs.js';
 
 // ---------------------------------------------------------------------------
 // Login
@@ -118,3 +119,37 @@ test('Breadcrumb renders Pipelines as active when showPipelines is set', () => {
 // Note: Notice is not exported from Layout.js (it is a file-private const),
 // so we cannot import it directly. Its output is tested indirectly via
 // integration / Selenium tests.
+
+// ---------------------------------------------------------------------------
+// StepRow — running step shows live elapsed time
+// ---------------------------------------------------------------------------
+
+test('StepRow shows live elapsed time when stepElapsed is provided for a started step', () => {
+  const isAutoScrollingRef = { current: false };
+  const step = { type: 'task', name: 'build', status: 'started', duration: 0, logs: '' };
+  const output = render(html`<${StepRow}
+    step=${step}
+    expanded=${false}
+    onToggle=${() => {}}
+    autoFollow=${false}
+    setAutoFollow=${() => {}}
+    isAutoScrollingRef=${isAutoScrollingRef}
+    stepElapsed=${{ build: '00:00:42' }}
+  />`);
+  assert.ok(output.includes('00:00:42'), 'should show live elapsed time for running step');
+});
+
+test('StepRow shows duration when step is completed and stepElapsed not provided', () => {
+  const isAutoScrollingRef = { current: false };
+  const step = { type: 'task', name: 'build', status: 'succeeded', duration: '00:00:05', logs: '' };
+  const output = render(html`<${StepRow}
+    step=${step}
+    expanded=${false}
+    onToggle=${() => {}}
+    autoFollow=${false}
+    setAutoFollow=${() => {}}
+    isAutoScrollingRef=${isAutoScrollingRef}
+    stepElapsed=${{}}
+  />`);
+  assert.ok(output.includes('00:00:05'), 'should show completed step duration');
+});

--- a/worker/service.go
+++ b/worker/service.go
@@ -816,7 +816,7 @@ func (w *Worker) runInParallelStep(
 	// Add parent step placeholder
 	parentIdx := len(b.Steps)
 	b.Steps = append(b.Steps, build.Step{
-		Type: "in_parallel", Status: build.Started,
+		Type: "in_parallel", Status: build.Started, StartedAt: nowPtr(),
 	})
 	w.updateBuild(ctx, m, *b)
 
@@ -1039,7 +1039,7 @@ func (w *Worker) runIfStep(
 		label = ifStep.Branches[0].Label
 	}
 	b.Steps = append(b.Steps, build.Step{
-		Type: "if", Name: label, Status: build.Started,
+		Type: "if", Name: label, Status: build.Started, StartedAt: nowPtr(),
 	})
 	w.updateBuild(ctx, m, *b)
 
@@ -1081,7 +1081,7 @@ func (w *Worker) runIfStep(
 			// shows the entered branch immediately.
 			branchIdx := len(subSteps)
 			subSteps = append(subSteps, build.Step{
-				Type: branch.Type, Name: branchName, Status: build.Started,
+				Type: branch.Type, Name: branchName, Status: build.Started, StartedAt: nowPtr(),
 			})
 			b.Steps[parentIdx].SubSteps = subSteps
 			w.updateBuild(ctx, m, *b)
@@ -1265,7 +1265,7 @@ func (w *Worker) runGetStep(ctx context.Context, m workitem.Body, b *build.Build
 
 	// Append a "running" step and persist it
 	stepIdx := len(b.Steps)
-	b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Status: build.Started})
+	b.Steps = append(b.Steps, build.Step{Type: "get", Name: g.Name, Status: build.Started, StartedAt: nowPtr()})
 	w.updateBuild(ctx, m, *b)
 
 	out := formatParamWarnings(pullWarnings)
@@ -1458,7 +1458,7 @@ func (w *Worker) runTaskStep(ctx context.Context, m workitem.Body, b *build.Buil
 
 	// Append a "running" step and persist it
 	stepIdx := len(b.Steps)
-	b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Status: build.Started})
+	b.Steps = append(b.Steps, build.Step{Type: "task", Name: t.Name, Status: build.Started, StartedAt: nowPtr()})
 	w.updateBuild(ctx, m, *b)
 
 	out := formatParamWarnings(taskWarnings)
@@ -1624,7 +1624,7 @@ func (w *Worker) runPutStep(ctx context.Context, m workitem.Body, b *build.Build
 
 	// Append a "running" step and persist it
 	stepIdx := len(b.Steps)
-	b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Status: build.Started})
+	b.Steps = append(b.Steps, build.Step{Type: "put", Name: p.Name, Status: build.Started, StartedAt: nowPtr()})
 	w.updateBuild(ctx, m, *b)
 
 	out := formatParamWarnings(putWarnings)
@@ -1831,7 +1831,7 @@ func (w *Worker) runNotifyStep(ctx context.Context, m workitem.Body, b *build.Bu
 
 	// Append a "running" step and persist it
 	stepIdx := len(b.Steps)
-	b.Steps = append(b.Steps, build.Step{Type: "notify", Name: n.Name, Status: build.Started})
+	b.Steps = append(b.Steps, build.Step{Type: "notify", Name: n.Name, Status: build.Started, StartedAt: nowPtr()})
 	w.updateBuild(ctx, m, *b)
 
 	out := formatParamWarnings(notifyWarnings)
@@ -2080,7 +2080,7 @@ func (w *Worker) runHooks(ctx context.Context, m workitem.Body, b *build.Build, 
 
 			// Append a "running" step and persist it
 			stepIdx := len(*steps)
-			*steps = append(*steps, build.Step{Type: "hook", Name: name, Status: build.Started})
+			*steps = append(*steps, build.Step{Type: "hook", Name: name, Status: build.Started, StartedAt: nowPtr()})
 			w.updateBuild(ctx, m, *b)
 
 			onPartialLog := func(partial string) {
@@ -2455,6 +2455,9 @@ func (w *Worker) failBuild(_ context.Context, m workitem.Body, b build.Build, er
 	}
 }
 
+// nowPtr returns a pointer to the current time, used when setting build.Step.StartedAt.
+func nowPtr() *time.Time { t := time.Now(); return &t }
+
 // updateBuildWithRetry retries the UpdateJobBuild call with exponential backoff.
 // This gives separated workers the best chance to report results when the server
 // is restarting.
@@ -2823,7 +2826,7 @@ func (w *Worker) startServices(ctx context.Context, m workitem.Body, b *build.Bu
 
 		// Append a "running" step and persist it
 		stepIdx := len(b.Steps)
-		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Status: build.Started})
+		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":start", Status: build.Started, StartedAt: nowPtr()})
 		w.updateBuild(ctx, m, *b)
 
 		svcWarnStr := formatParamWarnings(svcWarnings)
@@ -3107,7 +3110,7 @@ func (w *Worker) waitForServices(ctx context.Context, m workitem.Body, b *build.
 			continue
 		}
 		idx := len(b.Steps)
-		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":ready", Status: build.Started})
+		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":ready", Status: build.Started, StartedAt: nowPtr()})
 		refs = append(refs, readyStepRef{name: ss.Name, stepIdx: idx})
 	}
 	if len(refs) > 0 {
@@ -3266,7 +3269,7 @@ func (w *Worker) stopServices(m workitem.Body, b *build.Build, cwd string, pp *p
 
 		// Append a "running" step and persist it
 		stepIdx := len(b.Steps)
-		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":stop", Status: build.Started})
+		b.Steps = append(b.Steps, build.Step{Type: "service", Name: ss.Name + ":stop", Status: build.Started, StartedAt: nowPtr()})
 		w.updateBuild(stopCtx, m, *b)
 
 		stopWarnStr := formatParamWarnings(stopWarnings)

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -200,6 +200,71 @@ func TestProcessJob_Success_TaskOnly(t *testing.T) {
 	w.processJob(ctx, m, cwd, pp)
 }
 
+func TestProcessJob_StepStartedAt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "echo-job",
+		BuildID:           10,
+		BuildNumber:       "10",
+	}
+	pp := &pipeline.Pipeline{
+		ID:   1,
+		Name: "test-pipeline",
+		Jobs: []job.Job{
+			{
+				ID:   1,
+				Name: "echo-job",
+				Plan: []job.PlanStep{
+					{
+						Type: job.StepTypeTask,
+						Task: &job.TaskStep{
+							Name: "echo",
+							Run: utils.RunnerCommand{
+								Runner: "exec",
+								Args:   []string{"hello"},
+								Params: map[string]string{
+									"path": "echo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Runners: []runner.Runner{
+			{Name: "exec", Run: utils.RunCommand{Path: "$path", Args: []string{"$args"}}},
+		},
+	}
+	cwd := t.TempDir()
+
+	svc.EXPECT().GetPipelineJob(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName).
+		Return(&pp.Jobs[0], nil)
+
+	var capturedStartedAt *time.Time
+	svc.EXPECT().UpdateJobBuild(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, m.JobName, "10", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _, _ string, b build.Build) error {
+			if capturedStartedAt == nil {
+				for _, s := range b.Steps {
+					if s.Status == build.Started {
+						capturedStartedAt = s.StartedAt
+						break
+					}
+				}
+			}
+			return nil
+		}).AnyTimes()
+
+	w.processJob(ctx, m, cwd, pp)
+
+	require.NotNil(t, capturedStartedAt, "started step should have StartedAt set")
+	assert.False(t, capturedStartedAt.IsZero(), "started step StartedAt should not be zero")
+}
+
 func TestProcessJob_Success_WithGetAndTask(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc := newTestWorker(ctrl)


### PR DESCRIPTION
- Add `StartedAt *time.Time` to `build.Step`; set at all step-start sites in the worker
- Compute per-step elapsed in the 1s interval using server `started_at` or a client-side first-seen timestamp as fallback (works even before backend is upgraded)
- Always render step duration; show live counting elapsed for `started` steps

Closes #655