### PR TITLE
fix: use path.Join instead of filepath.Join for embed.FS lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Windows startup panic loading embedded templates**: template path lookups now use `path.Join` instead of `filepath.Join`, since `embed.FS` requires forward slashes on every OS ([#641](https://github.com/PikoCI/pikoci/issues/641)).
 - **Running step elapsed time not shown**: Steps currently in progress now display a live-updating elapsed timer (matching the format of completed steps), consistent with the global build timer already shown at the top of the page ([#655](https://github.com/PikoCI/pikoci/issues/655)).
 - **Services inside `if` branches not stopped**: services started within an `if` branch are now returned to the plan runner and stopped correctly, even when the branch fails ([#664](https://github.com/PikoCI/pikoci/issues/664)).
 - **Consecutive `if` blocks merged into one chain**: a second `if` block now starts an independent conditional chain; previously it was treated as a continuation, causing `else`/`else_if` blocks to attach to the wrong `if` ([#664](https://github.com/PikoCI/pikoci/issues/664)).

--- a/pikoci/transport/http/templates/template.go
+++ b/pikoci/transport/http/templates/template.go
@@ -6,7 +6,7 @@ package templates
 import (
 	"embed"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"text/template"
 )
 
@@ -19,7 +19,7 @@ const (
 
 var (
 	// layoutsDir is the directory containing layout template files.
-	layoutsDir = filepath.Join(viewsDir, "layouts")
+	layoutsDir = path.Join(viewsDir, "layouts")
 
 	//go:embed views/layouts/*
 	files embed.FS
@@ -37,19 +37,19 @@ func init() {
 	loadTemplates(viewsDir)
 }
 
-func loadTemplates(path string) error {
-	tmplFiles, err := fs.ReadDir(files, path)
+func loadTemplates(p string) error {
+	tmplFiles, err := fs.ReadDir(files, p)
 	if err != nil {
 		panic(err)
 	}
 
 	for _, tmpl := range tmplFiles {
 		if tmpl.IsDir() {
-			loadTemplates(filepath.Join(path, tmpl.Name()))
+			loadTemplates(path.Join(p, tmpl.Name()))
 			continue
 		}
 
-		newpath := filepath.Join(path, tmpl.Name())
+		newpath := path.Join(p, tmpl.Name())
 
 		if _, ok := Templates[newpath]; ok {
 			continue
@@ -57,7 +57,7 @@ func loadTemplates(path string) error {
 
 		pt := template.New(tmpl.Name())
 
-		pt, err := pt.ParseFS(files, newpath, filepath.Join(layoutsDir, extension))
+		pt, err := pt.ParseFS(files, newpath, path.Join(layoutsDir, extension))
 		if err != nil {
 			panic(err)
 		}

--- a/pikoci/transport/http/templates/template_test.go
+++ b/pikoci/transport/http/templates/template_test.go
@@ -1,0 +1,42 @@
+package templates
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTemplatesLoaded(t *testing.T) {
+	if _, ok := Templates["views/layouts/index.tmpl"]; !ok {
+		keys := make([]string, 0, len(Templates))
+		for k := range Templates {
+			keys = append(keys, k)
+		}
+		t.Fatalf("expected Templates to contain %q, got keys: %v", "views/layouts/index.tmpl", keys)
+	}
+}
+
+// TestNoFilepathImport guards against reintroducing path/filepath for embed.FS
+// lookups. filepath.Join and path.Join produce identical output on the
+// Linux/macOS CI runner, so a runtime check on Templates' keys can never
+// catch this regression here — only a real Windows run would panic. This
+// static check on the source fails on every OS instead.
+func TestNoFilepathImport(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("failed to list package files: %v", err)
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", f, err)
+		}
+		if strings.Contains(string(src), `"path/filepath"`) {
+			t.Errorf("%s must not import path/filepath: embed.FS lookups require forward slashes on every OS, use the path package instead", f)
+		}
+	}
+}


### PR DESCRIPTION
- Replace `filepath.Join` with `path.Join` when building lookup paths into the embedded templates `embed.FS`, since `embed.FS`/`io/fs` require forward slashes on every OS while `filepath.Join` uses backslashes on Windows, causing a startup panic
- Rename the `loadTemplates` parameter from `path` to `p` to avoid shadowing the `path` package
- Add a regression test that statically checks the package's non-test source files never import `path/filepath`

Closes #641