### PR TITLE
Run as an init so orphaned processes get reaped

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,23 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     -o /pikoci .
 
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates git jq curl openssl docker-cli graphviz
+RUN apk add --no-cache ca-certificates git jq curl openssl docker-cli graphviz tini
 COPY --from=builder /pikoci /usr/local/bin/pikoci
-ENTRYPOINT ["pikoci"]
+
+# tini is PID 1 so that orphaned processes get reaped.
+#
+# Resource checks run shell scripts that spawn git, curl and their own transport
+# helpers. When one of those outlives its parent — a clone still running when the
+# script is killed, a helper that outlives the git that started it — the kernel
+# reparents it to PID 1, and reaping it becomes PID 1's job. pikoci waits on the
+# processes it starts itself, but it never adopted a duty to wait on strangers,
+# so as PID 1 it accumulated them: 9,000 defunct git processes in three days on
+# one deployment, until the container hit its pids cgroup limit and every
+# subsequent fork failed with EAGAIN. The symptom is the whole server appearing
+# to hang, reporting "can't fork: Resource temporarily unavailable".
+#
+# An init rather than a reaper goroutine inside pikoci: a process that calls
+# wait4(-1) races with os/exec, which is waiting on specific pids of its own, and
+# whichever wins steals the other's exit status. Keeping the two jobs in separate
+# processes is why init exists.
+ENTRYPOINT ["/sbin/tini", "--", "pikoci"]


### PR DESCRIPTION
## The problem

`pikoci` is `ENTRYPOINT`, so it runs as **PID 1** and inherits every orphaned process in the namespace. It waits on the processes it starts (`cmd.Start()`/`cmd.Wait()` in `worker/service.go`), but never reaps the strangers PID 1 is handed — `git` and `curl` transport helpers outliving the check scripts that spawned them. They accumulate as zombies forever.

## What it looks like in production

On one deployment this reached **9,237 defunct `git` processes over three days**, at which point the container hit its pids cgroup limit (`pids.current = 9249`, `pids.max = 9250`). Every `fork()` after that failed:

```
/bin/sh: can't fork: Resource temporarily unavailable
```

The message names neither pids nor zombies, so it sends operators looking at memory — which was fine throughout. A restart clears it and it returns in about a day.

## The fix

Install `tini` and make it PID 1. Orphans are reparented to tini, which reaps them; pikoci moves to PID 2 and keeps waiting on its own children exactly as before.

Not a reaper goroutine inside pikoci: anything calling `wait4(-1)` races with `os/exec` waiting on specific pids, and whichever gets there first steals the other's exit status — turning a slow leak into intermittently failing builds.

## Verification

`tini` is PID 1 in the built image; an orphan created inside the container is reaped rather than left defunct (`zombies=0`; the unpatched image accumulates them); `pikoci` starts normally under it; SIGTERM still reaches it, so `docker stop` returns immediately.

Deployers who cannot rebuild can get the same effect today with `docker run --init`.
