### PR TITLE
fix: resolve each get's version from its own resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Second `get` in a job never resolved**: a build carries the version of the resource whose check produced it, and `buildPullParams` applied that id to every `get` in the plan. For any other resource the lookup searched a different resource's history for an id that could not be there, failing the build with `no version found for resource "..."` — so a job getting two resources could never run, whichever one triggered. The queue's version now applies only to the resource named by `ResourceCanonical`; every other `get` falls through to its latest, as the priority comment already described.
 - **Windows startup panic loading embedded templates**: template path lookups now use `path.Join` instead of `filepath.Join`, since `embed.FS` requires forward slashes on every OS ([#641](https://github.com/PikoCI/pikoci/issues/641)).
 - **Running step elapsed time not shown**: Steps currently in progress now display a live-updating elapsed timer (matching the format of completed steps), consistent with the global build timer already shown at the top of the page ([#655](https://github.com/PikoCI/pikoci/issues/655)).
 - **Services inside `if` branches not stopped**: services started within an `if` branch are now returned to the plan runner and stopped correctly, even when the branch fails ([#664](https://github.com/PikoCI/pikoci/issues/664)).

--- a/worker/service.go
+++ b/worker/service.go
@@ -1992,9 +1992,17 @@ func (w *Worker) buildPullParams(ctx context.Context, m workitem.Body, b *build.
 		return nil, 0, nil
 	}
 
-	// Version priority: resolvedVersionID (from passed constraints) > m.VersionID (from queue) > latest
+	// Version priority: resolvedVersionID (from passed constraints) > m.VersionID
+	// (from queue) > latest.
+	//
+	// The queue's version belongs to the one resource whose check produced this
+	// build, named by m.ResourceCanonical. Applying it to any other resource in
+	// the same job looks for that id among a different resource's versions,
+	// finds nothing, and fails the build with "no version found" — which is why
+	// a job with two gets could never run: whichever resource triggered
+	// resolved, and the other one always failed.
 	versionID := resolvedVersionID
-	if versionID == 0 {
+	if versionID == 0 && m.ResourceCanonical == r.Canonical {
 		versionID = m.VersionID
 	}
 

--- a/worker/service_test.go
+++ b/worker/service_test.go
@@ -1712,6 +1712,46 @@ func TestBuildPullParams_WithVersionID(t *testing.T) {
 	assert.Equal(t, uint32(5), vid)
 }
 
+// A job may get more than one resource. The build carries the version of the
+// resource whose check triggered it; every other resource in the plan takes its
+// latest, because that id means nothing in another resource's history.
+func TestBuildPullParams_OtherResourceInJob_UsesLatest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	w, svc := newTestWorker(ctrl)
+
+	ctx := context.Background()
+	// Triggered by a check on git.app, carrying that resource's version 5.
+	m := workitem.Body{
+		TeamCanonical:     "main",
+		PipelineCanonical: "test-pipeline",
+		JobName:           "test-job",
+		BuildID:           10,
+		ResourceCanonical: "git.app",
+		VersionID:         5,
+	}
+	b := build.Build{ID: 73, BuildNumber: "73"}
+
+	rt := restype.ResourceType{
+		Pull: &utils.RunnerCommand{
+			Params: map[string]string{},
+		},
+	}
+	// ... but this step gets the other resource, whose versions are 6 and 7.
+	r := resource.Resource{Canonical: "git.lib"}
+	g := job.GetStep{}
+
+	svc.EXPECT().ListResourceVersions(gomock.Any(), m.TeamCanonical, m.PipelineCanonical, "git.lib", (*uint32)(nil), (*uint32)(nil), uint32(0)).
+		Return([]*resource.Version{
+			{ID: 6, Version: map[string]interface{}{"ref": "old"}},
+			{ID: 7, Version: map[string]interface{}{"ref": "newest"}},
+		}, false, nil).AnyTimes()
+
+	params, vid, _ := w.buildPullParams(ctx, m, &b, rt, r, g, 0)
+	require.NotNil(t, params, "the build must not fail because version 5 belongs to another resource")
+	assert.Equal(t, "newest", params["version_ref"])
+	assert.Equal(t, uint32(7), vid)
+}
+
 func TestBuildPullParams_NoVersionID_UsesLatest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	w, svc := newTestWorker(ctrl)


### PR DESCRIPTION
## The problem

A job that gets two resources can never run. Whichever resource's check triggered the build is fetched correctly; the other always fails with:

```
no version found for resource "git.lib"
```

The failure follows the trigger — trigger from either side and the *other* `get` fails — so it is not a missing resource, credential, or version.

## The cause

In `worker/service.go`, `buildPullParams` falls back to `m.VersionID` — the version whose check produced this build — for every `get` in the plan. That id belongs only to `m.ResourceCanonical`, so every other resource searches its own history for an id that cannot be there.

## The fix

Honour the queue's version only for the resource it belongs to:

```go
if versionID == 0 && m.ResourceCanonical == r.Canonical {
```

Every other `get` falls through to its latest version — which is what the priority comment above the code already claimed happened.

## Tests

`TestBuildPullParams_OtherResourceInJob_UsesLatest`: a build triggered by `git.app` at version 5, resolving a `get` of `git.lib` whose versions are 6 and 7. With the fix reverted it fails with the production error; with the fix it takes version 7. `go test ./worker/...` is green.
