### PR TITLE
fix: fail git resource check when ls-remote finds no ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build list tabs show stale status**: Build tabs no longer stay stuck on "running" after a build completes — they now refresh automatically when a non-terminal build transitions to a terminal state.
 - **Trigger handler authorization bypass**: JSON body could override route vars to trigger jobs in unauthorized teams; body is now decoded before route vars are applied ([#644](https://github.com/PikoCI/pikoci/issues/644)).
 - **Active build data overwritten by stale snapshot**: The `onFullBuildFetched` callback now merges only enrichment fields (steps, approvals, version_metadata, pinned_versions) into the polling state rather than replacing the entire build object.
+- **Git resource check recording a bogus empty-ref version**: The `git` resource type's check now fails instead of returning an empty ref when `ls-remote` finds no matching ref, so a transient anonymous-request failure no longer gets recorded as a new version and triggers builds that fail on checkout ([#676](https://github.com/PikoCI/pikoci/issues/676)).
 
 ## [0.7.0] - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build list tabs show stale status**: Build tabs no longer stay stuck on "running" after a build completes — they now refresh automatically when a non-terminal build transitions to a terminal state.
 - **Trigger handler authorization bypass**: JSON body could override route vars to trigger jobs in unauthorized teams; body is now decoded before route vars are applied ([#644](https://github.com/PikoCI/pikoci/issues/644)).
 - **Active build data overwritten by stale snapshot**: The `onFullBuildFetched` callback now merges only enrichment fields (steps, approvals, version_metadata, pinned_versions) into the polling state rather than replacing the entire build object.
-- **Git resource check recording a bogus empty-ref version**: The `git` resource type's check now fails instead of returning an empty ref when `ls-remote` finds no matching ref, so a transient anonymous-request failure no longer gets recorded as a new version and triggers builds that fail on checkout ([#676](https://github.com/PikoCI/pikoci/issues/676)).
+- **Git resource check on empty ref**: `git` resource checks now fail instead of recording an empty-ref version when `ls-remote` finds no ref, which previously triggered builds that failed on checkout ([#676](https://github.com/PikoCI/pikoci/issues/676)).
 
 ## [0.7.0] - 2026-07-08
 

--- a/pikoci/builtin/resource_check_test.go
+++ b/pikoci/builtin/resource_check_test.go
@@ -185,6 +185,24 @@ func TestGitCheck_LsRemote_WithBranch(t *testing.T) {
 	assert.Equal(t, expectedSHA, versions[0]["ref"])
 }
 
+func TestGitCheck_LsRemote_NoMatchingRef_Fails(t *testing.T) {
+	bareDir := t.TempDir()
+	cmd := exec.Command("git", "init", "--bare")
+	cmd.Dir = bareDir
+	initOut, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git init --bare failed: %s", initOut)
+
+	rts := builtin.ResourceTypes()
+	rt := rts["git"]
+
+	out, err := runScript(t, rt.Check, t.TempDir(), map[string]string{
+		"param_url":    bareDir,
+		"param_branch": "does-not-exist",
+	})
+	require.Error(t, err, "expected git check to fail when ls-remote finds no ref, got: %s", out)
+	assert.Contains(t, out, "no ref")
+}
+
 func TestGitCheck_GitHubAPI_ReturnsSingleVersion(t *testing.T) {
 	cannedCommits := `[{"sha":"abc123"}]`
 	curlDir, logFile := fakeCurlDir(t, cannedCommits)

--- a/pikoci/builtin/resource_types/git.hcl
+++ b/pikoci/builtin/resource_types/git.hcl
@@ -254,6 +254,10 @@ resource_type "git" {
       if [ -z "$REF" ]; then
         REF=$(git ls-remote "$URL" HEAD | awk '{print $1}')
       fi
+      if [ -z "$REF" ]; then
+        echo "error: git ls-remote returned no ref for $URL $BRANCH" >&2
+        exit 1
+      fi
       echo "[{\"ref\":\"$REF\"}]"
       EOT
     ]


### PR DESCRIPTION
- Fail the git resource type's check script when both ls-remote attempts (branch, then HEAD) return no ref, instead of recording a bogus empty-ref version
- Add a regression test covering the no-matching-ref case

Closes #676