### PR TITLE
fix: secret store review follow-ups

### DIFF
--- a/cmd/secret_store.go
+++ b/cmd/secret_store.go
@@ -142,6 +142,9 @@ func readSecretValue(cmd *cobra.Command, name, value string, fromStdin, isSecret
 	} else {
 		var line string
 		line, err = readLine(os.Stdin)
+		if err == nil && strings.TrimSpace(line) == "" {
+			return "", fmt.Errorf("no value provided")
+		}
 		b = []byte(line)
 	}
 	if err != nil {

--- a/cmd/secret_store.go
+++ b/cmd/secret_store.go
@@ -21,6 +21,11 @@ var secretsCmd = &cobra.Command{
 		"and shown in build logs.",
 }
 
+// secretCommandLineRefusal is returned whenever a secret value would land on
+// the command line — as a positional argument or via --value — where it is
+// visible in shell history and the process list.
+const secretCommandLineRefusal = "refusing to read a secret from the command line, where it is visible in shell history and the process list: omit the value to be prompted, use --stdin, or pass --plain if it is not sensitive"
+
 func init() {
 	secretsCmd.AddCommand(secretsSetCmd)
 	secretsCmd.AddCommand(secretsListCmd)
@@ -60,7 +65,7 @@ var secretsSetCmd = &cobra.Command{
 				return fmt.Errorf("value given both as an argument and as --value")
 			}
 			if isSecret {
-				return fmt.Errorf("refusing to read a secret from the command line, where it is visible in shell history and the process list: omit the value to be prompted, use --stdin, or pass --plain if it is not sensitive")
+				return fmt.Errorf("%s", secretCommandLineRefusal)
 			}
 			value = args[1]
 		}
@@ -102,6 +107,9 @@ func readSecretValue(cmd *cobra.Command, name, value string, fromStdin, isSecret
 	}
 
 	if value != "" {
+		if isSecret {
+			return "", fmt.Errorf("%s", secretCommandLineRefusal)
+		}
 		return value, nil
 	}
 

--- a/cmd/secret_store.go
+++ b/cmd/secret_store.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -140,7 +141,7 @@ func readSecretValue(cmd *cobra.Command, name, value string, fromStdin, isSecret
 		fmt.Fprintln(os.Stderr)
 	} else {
 		var line string
-		_, err = fmt.Scanln(&line)
+		line, err = readLine(os.Stdin)
 		b = []byte(line)
 	}
 	if err != nil {
@@ -151,6 +152,17 @@ func readSecretValue(cmd *cobra.Command, name, value string, fromStdin, isSecret
 	}
 
 	return string(b), nil
+}
+
+// readLine reads one line from r, preserving internal spaces — unlike
+// fmt.Scanln, which splits on whitespace and errors on anything but a single
+// token followed immediately by a newline.
+func readLine(r io.Reader) (string, error) {
+	line, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
 }
 
 var secretsListCmd = &cobra.Command{

--- a/cmd/secret_store_test.go
+++ b/cmd/secret_store_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadSecretValue_ValueFlagRefusesSecret(t *testing.T) {
+	cmd := &cobra.Command{}
+	_, err := readSecretValue(cmd, "TOKEN", "ghp_from_flag", false, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to read a secret from the command line")
+}
+
+func TestReadSecretValue_ValueFlagAllowsPlain(t *testing.T) {
+	cmd := &cobra.Command{}
+	v, err := readSecretValue(cmd, "LABEL", "staging", false, false)
+	require.NoError(t, err)
+	assert.Equal(t, "staging", v)
+}
+
+func TestReadSecretValue_ValueAndStdinMutuallyExclusive(t *testing.T) {
+	cmd := &cobra.Command{}
+	_, err := readSecretValue(cmd, "TOKEN", "x", true, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}

--- a/cmd/secret_store_test.go
+++ b/cmd/secret_store_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -27,4 +28,22 @@ func TestReadSecretValue_ValueAndStdinMutuallyExclusive(t *testing.T) {
 	_, err := readSecretValue(cmd, "TOKEN", "x", true, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestReadLine_PreservesSpaces(t *testing.T) {
+	got, err := readLine(strings.NewReader("staging server\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "staging server", got)
+}
+
+func TestReadLine_NoTrailingNewline(t *testing.T) {
+	got, err := readLine(strings.NewReader("staging server"))
+	require.NoError(t, err)
+	assert.Equal(t, "staging server", got)
+}
+
+func TestReadLine_TrimsCarriageReturn(t *testing.T) {
+	got, err := readLine(strings.NewReader("staging server\r\n"))
+	require.NoError(t, err)
+	assert.Equal(t, "staging server", got)
 }

--- a/pikoci/mock/service.go
+++ b/pikoci/mock/service.go
@@ -1600,6 +1600,21 @@ func (mr *ServiceMockRecorder) UserLogin(ctx, un, pass any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserLogin", reflect.TypeOf((*Service)(nil).UserLogin), ctx, un, pass)
 }
 
+// VerifyTeamWorkerTokenSalt mocks base method.
+func (m *Service) VerifyTeamWorkerTokenSalt(ctx context.Context, tc, salt string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyTeamWorkerTokenSalt", ctx, tc, salt)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VerifyTeamWorkerTokenSalt indicates an expected call of VerifyTeamWorkerTokenSalt.
+func (mr *ServiceMockRecorder) VerifyTeamWorkerTokenSalt(ctx, tc, salt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyTeamWorkerTokenSalt", reflect.TypeOf((*Service)(nil).VerifyTeamWorkerTokenSalt), ctx, tc, salt)
+}
+
 // WebhookTrigger mocks base method.
 func (m *Service) WebhookTrigger(ctx context.Context, token string) error {
 	m.ctrl.T.Helper()

--- a/pikoci/mysql/secret.go
+++ b/pikoci/mysql/secret.go
@@ -156,7 +156,7 @@ func (r *SecretRepository) resolveTeamID(ctx context.Context, tc string) (uint32
 	var id uint32
 	err := r.querier.QueryRowContext(ctx, `SELECT id FROM teams WHERE canonical = ?`, tc).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("team %q not found", tc)
+		return 0, fmt.Errorf("%w: team %q not found", secret.ErrScopeNotFound, tc)
 	}
 	if err != nil {
 		return 0, fmt.Errorf("failed to find team %q: %w", tc, err)
@@ -172,7 +172,7 @@ func (r *SecretRepository) resolvePipelineID(ctx context.Context, tc, pn string)
 		WHERE t.canonical = ? AND p.canonical = ?
 	`, tc, pn).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("pipeline %q not found in team %q", pn, tc)
+		return 0, fmt.Errorf("%w: pipeline %q not found in team %q", secret.ErrScopeNotFound, pn, tc)
 	}
 	if err != nil {
 		return 0, fmt.Errorf("failed to find pipeline %q: %w", pn, err)

--- a/pikoci/mysql/secret_test.go
+++ b/pikoci/mysql/secret_test.go
@@ -126,6 +126,30 @@ func TestSecret_ServerKeyRoundTrip(t *testing.T) {
 		"a second key must be rejected so stored values are never orphaned")
 }
 
+func TestSecret_UpsertTeam_TeamNotFound(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	repo := mysql.NewSecretRepository(db)
+
+	s := secret.Entry{Name: "TOKEN", Canonical: "token", Kind: secret.KindSecret}
+	_, err := repo.UpsertTeam(ctx, "no-such-team", s, []byte("cipher"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, secret.ErrScopeNotFound)
+	assert.Contains(t, err.Error(), `team "no-such-team" not found`)
+}
+
+func TestSecret_UpsertPipeline_PipelineNotFound(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	repo := mysql.NewSecretRepository(db)
+
+	s := secret.Entry{Name: "TOKEN", Canonical: "token", Kind: secret.KindSecret}
+	_, err := repo.UpsertPipeline(ctx, "main", "no-such-pipeline", s, []byte("cipher"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, secret.ErrScopeNotFound)
+	assert.Contains(t, err.Error(), `pipeline "no-such-pipeline" not found in team "main"`)
+}
+
 // findSecret locates a secret by canonical name. Tests share one in-memory
 // database, so assertions are scoped to names rather than to list length.
 func findSecret(secrets []*secret.Entry, canonical string) *secret.Entry {

--- a/pikoci/secret/secret.go
+++ b/pikoci/secret/secret.go
@@ -5,7 +5,16 @@
 // build time.
 package secret
 
-import "time"
+import (
+	"errors"
+	"time"
+)
+
+// ErrScopeNotFound reports that the team or pipeline an entry was scoped to
+// does not exist. It is returned by the storage layer, which cannot import
+// the pikoci package's ErrSecretEntryNotFound (that would be an import
+// cycle) — callers in pikoci translate it at the service boundary instead.
+var ErrScopeNotFound = errors.New("scope not found")
 
 // Scope identifies what an entry is attached to.
 type Scope string

--- a/pikoci/secret_store.go
+++ b/pikoci/secret_store.go
@@ -133,6 +133,16 @@ func checkKindUnchanged(entries []*secret.Entry, name string, kind secret.Kind) 
 	return fmt.Errorf("%w: %q is already stored as %s; delete it before storing it as %s", ErrSecretInvalidRequest, name, stored, kind)
 }
 
+// wrapStoreErr translates a scope-not-found failure from the storage layer
+// into ErrSecretEntryNotFound, matching the sentinel the HTTP layer maps to
+// 404 rather than 500. Any other storage failure is wrapped plainly.
+func wrapStoreErr(name string, err error) error {
+	if errors.Is(err, secret.ErrScopeNotFound) {
+		return fmt.Errorf("%w: %v", ErrSecretEntryNotFound, err)
+	}
+	return fmt.Errorf("failed to store %q: %w", name, err)
+}
+
 // SetTeamSecret stores a team-scoped entry, replacing the value of any
 // existing entry with the same name.
 func (q *PikoCI) SetTeamSecret(ctx context.Context, tc, name, value string, kind secret.Kind) error {
@@ -154,10 +164,7 @@ func (q *PikoCI) SetTeamSecret(ctx context.Context, tc, name, value string, kind
 		}
 
 		if _, err := uow.Secrets().UpsertTeam(ctx, tc, e, data); err != nil {
-			if errors.Is(err, secret.ErrScopeNotFound) {
-				return fmt.Errorf("%w: %v", ErrSecretEntryNotFound, err)
-			}
-			return fmt.Errorf("failed to store %q: %w", name, err)
+			return wrapStoreErr(name, err)
 		}
 
 		return nil
@@ -189,10 +196,7 @@ func (q *PikoCI) SetPipelineSecret(ctx context.Context, tc, pn, name, value stri
 		}
 
 		if _, err := uow.Secrets().UpsertPipeline(ctx, tc, pn, e, data); err != nil {
-			if errors.Is(err, secret.ErrScopeNotFound) {
-				return fmt.Errorf("%w: %v", ErrSecretEntryNotFound, err)
-			}
-			return fmt.Errorf("failed to store %q: %w", name, err)
+			return wrapStoreErr(name, err)
 		}
 
 		return nil

--- a/pikoci/secret_store.go
+++ b/pikoci/secret_store.go
@@ -155,6 +155,9 @@ func (q *PikoCI) SetTeamSecret(ctx context.Context, tc, name, value string, kind
 		}
 
 		if _, err := uow.Secrets().UpsertTeam(ctx, tc, e, data); err != nil {
+			if errors.Is(err, secret.ErrScopeNotFound) {
+				return fmt.Errorf("%w: %v", ErrSecretEntryNotFound, err)
+			}
 			return fmt.Errorf("failed to store %q: %w", name, err)
 		}
 
@@ -187,6 +190,9 @@ func (q *PikoCI) SetPipelineSecret(ctx context.Context, tc, pn, name, value stri
 		}
 
 		if _, err := uow.Secrets().UpsertPipeline(ctx, tc, pn, e, data); err != nil {
+			if errors.Is(err, secret.ErrScopeNotFound) {
+				return fmt.Errorf("%w: %v", ErrSecretEntryNotFound, err)
+			}
 			return fmt.Errorf("failed to store %q: %w", name, err)
 		}
 

--- a/pikoci/secret_store.go
+++ b/pikoci/secret_store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/pikoci/pikoci/pikoci/auditlog"
 	"github.com/pikoci/pikoci/pikoci/pipeline"
@@ -12,12 +11,6 @@ import (
 	"github.com/pikoci/pikoci/pikoci/sectype"
 	"github.com/pikoci/pikoci/pikoci/unitwork"
 )
-
-// secretNameRe constrains entry names to the shape of an environment
-// variable. Names are used verbatim as the lookup key from a pipeline's
-// secret block, so unlike other entities they are not slugified: turning
-// GITHUB_TOKEN into github-token would break `key = "GITHUB_TOKEN"`.
-var secretNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,254}$`)
 
 // EnableSecretStore wires up the secret store. An empty masterKey
 // leaves the store fully usable for plain entries but unconfigured for
@@ -47,8 +40,14 @@ func (q *PikoCI) secretStoreReady() error {
 	return nil
 }
 
+// validateSecretName constrains entry names to the shape of an environment
+// variable, reusing the same character-class rule pipeline input names use
+// (validInputName, in helper.go) plus the VARCHAR(255) bound the secrets
+// tables enforce. Names are used verbatim as the lookup key from a pipeline's
+// secret block, so unlike other entities they are not slugified: turning
+// GITHUB_TOKEN into github-token would break `key = "GITHUB_TOKEN"`.
 func validateSecretName(name string) error {
-	if !secretNameRe.MatchString(name) {
+	if !validInputName.MatchString(name) || len(name) > 255 {
 		return fmt.Errorf("%w: name %q must start with a letter or underscore and contain only letters, digits and underscores", ErrSecretInvalidRequest, name)
 	}
 	return nil

--- a/pikoci/secret_store_test.go
+++ b/pikoci/secret_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -173,6 +174,18 @@ func TestSetSecret_RejectsInvalidNames(t *testing.T) {
 
 	assert.NoError(t, svc.SetTeamSecret(ctx, tc, "VALID_NAME_1", "value", secret.KindSecret))
 	assert.NoError(t, svc.SetTeamSecret(ctx, tc, "_leading_underscore", "value", secret.KindSecret))
+}
+
+func TestSetSecret_RejectsNameOverMaxLength(t *testing.T) {
+	ctx := context.Background()
+	svc, _, tc, _ := newSecretStoreService(t, "master-key")
+
+	tooLong := "A" + strings.Repeat("b", 255) // 256 chars, over the VARCHAR(255) column
+	err := svc.SetTeamSecret(ctx, tc, tooLong, "value", secret.KindSecret)
+	assert.Error(t, err)
+
+	fits := "A" + strings.Repeat("b", 254) // exactly 255 chars
+	assert.NoError(t, svc.SetTeamSecret(ctx, tc, fits, "value", secret.KindSecret))
 }
 
 // Values must be unreadable in the database without the master key.

--- a/pikoci/secret_store_test.go
+++ b/pikoci/secret_store_test.go
@@ -199,11 +199,14 @@ func TestSetSecret_UnknownScopeReportsClearly(t *testing.T) {
 
 	err := svc.SetPipelineSecret(ctx, tc, "does-not-exist", "TOKEN", "value", secret.KindSecret)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, pikoci.ErrSecretEntryNotFound,
+		"a missing pipeline must map to the same sentinel the HTTP layer maps to 404")
 	assert.Contains(t, err.Error(), `pipeline "does-not-exist" not found`,
 		"a missing pipeline should say so, not surface a constraint violation")
 
 	err = svc.SetTeamSecret(ctx, "no-such-team", "TOKEN", "value", secret.KindSecret)
 	require.Error(t, err)
+	assert.ErrorIs(t, err, pikoci.ErrSecretEntryNotFound)
 	assert.Contains(t, err.Error(), `team "no-such-team" not found`)
 }
 

--- a/pikoci/service.go
+++ b/pikoci/service.go
@@ -303,6 +303,10 @@ type Service interface {
 	// GetTeamWorkerToken returns the current team worker token, or empty string
 	// if none has been generated.
 	GetTeamWorkerToken(ctx context.Context, tc string) (string, error)
+	// VerifyTeamWorkerTokenSalt reports whether salt is still the team's
+	// current worker token salt, i.e. whether a team-scoped worker JWT
+	// carrying it has not been revoked by a token regeneration.
+	VerifyTeamWorkerTokenSalt(ctx context.Context, tc, salt string) (bool, error)
 
 	// GetAuthMethods returns the enabled auth methods for the login page.
 	GetAuthMethods(ctx context.Context) (*oauthprovider.AuthMethods, error)

--- a/pikoci/team_worker_token.go
+++ b/pikoci/team_worker_token.go
@@ -37,6 +37,20 @@ func (q *PikoCI) GetTeamWorkerToken(ctx context.Context, tc string) (string, err
 	return signTeamWorkerJWT(q.JWTSecret, tc, salt), nil
 }
 
+// VerifyTeamWorkerTokenSalt reports whether salt is still the team's current
+// worker token salt. GenerateTeamWorkerToken rotates the salt on every
+// (re)generation, so a JWT signed with a previous salt fails here even
+// though it remains HMAC-valid against the server's signing secret — this is
+// how a worker token is actually revoked. It is the HTTP-layer counterpart
+// to the salt check the gRPC worker-auth path already performs.
+func (q *PikoCI) VerifyTeamWorkerTokenSalt(ctx context.Context, tc, salt string) (bool, error) {
+	dbSalt, err := q.Teams.FindWorkerTokenSalt(ctx, tc)
+	if err != nil {
+		return false, fmt.Errorf("failed to find worker token salt: %w", err)
+	}
+	return dbSalt != "" && dbSalt == salt, nil
+}
+
 func signTeamWorkerJWT(jwtSecret []byte, tc, salt string) string {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"is_from_worker": true,

--- a/pikoci/team_worker_token_test.go
+++ b/pikoci/team_worker_token_test.go
@@ -114,3 +114,51 @@ func TestGenerateTeamWorkerToken_RoundTrip(t *testing.T) {
 	salt, _ := claims["salt"].(string)
 	assert.Equal(t, storedSalt, salt, "salt claim must match stored salt")
 }
+
+func TestVerifyTeamWorkerTokenSalt_Valid(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Teams.EXPECT().FindWorkerTokenSalt(gomock.Any(), "main").Return("current-salt", nil)
+
+	valid, err := s.P.VerifyTeamWorkerTokenSalt(ctx, "main", "current-salt")
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestVerifyTeamWorkerTokenSalt_Stale(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Teams.EXPECT().FindWorkerTokenSalt(gomock.Any(), "main").Return("current-salt", nil)
+
+	valid, err := s.P.VerifyTeamWorkerTokenSalt(ctx, "main", "stale-salt")
+	require.NoError(t, err)
+	assert.False(t, valid, "a rotated salt must invalidate the old token")
+}
+
+func TestVerifyTeamWorkerTokenSalt_NoTokenGenerated(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Teams.EXPECT().FindWorkerTokenSalt(gomock.Any(), "main").Return("", nil)
+
+	valid, err := s.P.VerifyTeamWorkerTokenSalt(ctx, "main", "any-salt")
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestVerifyTeamWorkerTokenSalt_LookupError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := newService(ctrl)
+	ctx := context.TODO()
+
+	s.Teams.EXPECT().FindWorkerTokenSalt(gomock.Any(), "main").Return("", fmt.Errorf("db connection lost"))
+
+	_, err := s.P.VerifyTeamWorkerTokenSalt(ctx, "main", "any-salt")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to find worker token salt")
+}

--- a/pikoci/transport/http/authorization_test.go
+++ b/pikoci/transport/http/authorization_test.go
@@ -946,24 +946,49 @@ func TestWorkerTokenSecretValuesAuthorization(t *testing.T) {
 		// teamCanonical is the team claim on the worker JWT; empty means an
 		// unscoped global worker token.
 		teamCanonical string
-		path          string
-		wantOK        bool
+		// salt is the salt claim on the worker JWT; empty means the claim is
+		// omitted entirely.
+		salt string
+		// saltValid is what VerifyTeamWorkerTokenSalt should report for salt.
+		// Only consulted (mock set up) when teamCanonical and salt are both set.
+		saltValid bool
+		path      string
+		wantOK    bool
 	}{
 		{
 			name:          "team-scoped worker reads its own team",
 			teamCanonical: "main",
+			salt:          "current-salt",
+			saltValid:     true,
 			path:          "/teams/main/pipelines/p/secret-values",
 			wantOK:        true,
 		},
 		{
 			name:          "team-scoped worker denied another team",
 			teamCanonical: "main",
+			salt:          "current-salt",
+			saltValid:     true,
 			path:          "/teams/other/pipelines/p/secret-values",
 			wantOK:        false,
 		},
 		{
 			name:          "unscoped global worker denied",
 			teamCanonical: "",
+			path:          "/teams/main/pipelines/p/secret-values",
+			wantOK:        false,
+		},
+		{
+			name:          "team-scoped worker denied after token rotation (stale salt)",
+			teamCanonical: "main",
+			salt:          "stale-salt",
+			saltValid:     false,
+			path:          "/teams/main/pipelines/p/secret-values",
+			wantOK:        false,
+		},
+		{
+			name:          "team-scoped worker denied when JWT carries no salt claim",
+			teamCanonical: "main",
+			salt:          "",
 			path:          "/teams/main/pipelines/p/secret-values",
 			wantOK:        false,
 		},
@@ -980,10 +1005,17 @@ func TestWorkerTokenSecretValuesAuthorization(t *testing.T) {
 
 			svc.EXPECT().ResolvePipelineValues(gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(&secret.Resolved{Values: map[string]string{"TOKEN": "value"}}, nil).AnyTimes()
+			if tt.teamCanonical != "" && tt.salt != "" {
+				svc.EXPECT().VerifyTeamWorkerTokenSalt(gomock.Any(), tt.teamCanonical, tt.salt).
+					Return(tt.saltValid, nil).AnyTimes()
+			}
 
 			claims := jwt.MapClaims{"is_from_worker": true}
 			if tt.teamCanonical != "" {
 				claims["team_canonical"] = tt.teamCanonical
+			}
+			if tt.salt != "" {
+				claims["salt"] = tt.salt
 			}
 			token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 			jwtStr, err := token.SignedString(jwtSecret)
@@ -1010,6 +1042,39 @@ func TestWorkerTokenSecretValuesAuthorization(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWorkerTokenRevokedAfterTokenRegeneration is the end-to-end version of
+// the salt checks above: it simulates an admin regenerating a team's worker
+// token (changing the DB-side salt) and confirms a worker still holding the
+// old token is denied, proving revocation actually works over HTTP.
+func TestWorkerTokenRevokedAfterTokenRegeneration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	svc := mock.NewService(ctrl)
+	jwtSecret := []byte("test-secret")
+	handler := Handler(svc, jwtSecret, slog.Default(), nil, "", "test", "abc", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// The admin's regeneration replaced the DB salt with "new-salt"; this
+	// worker's JWT still carries the pre-rotation "old-salt".
+	svc.EXPECT().VerifyTeamWorkerTokenSalt(gomock.Any(), "main", "old-salt").Return(false, nil)
+
+	claims := jwt.MapClaims{"is_from_worker": true, "team_canonical": "main", "salt": "old-salt"}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	jwtStr, err := token.SignedString(jwtSecret)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/teams/main/pipelines/p/secret-values", strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+jwtStr)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "a token signed with a rotated-out salt must be denied")
 }
 
 // TestWorkerTokenDeniedOnSecretManagement covers the other half of the same

--- a/pikoci/transport/http/client/client.go
+++ b/pikoci/transport/http/client/client.go
@@ -1408,6 +1408,11 @@ func (cl *Client) GetTeamWorkerToken(ctx context.Context, tc string) (string, er
 	return resp.Token, nil
 }
 
+// VerifyTeamWorkerTokenSalt is not implemented on the client (server-side only).
+func (cl *Client) VerifyTeamWorkerTokenSalt(ctx context.Context, tc, salt string) (bool, error) {
+	return false, fmt.Errorf("VerifyTeamWorkerTokenSalt is not available on the client")
+}
+
 // OAuth stubs — the HTTP client is only used for worker and CLI operations,
 // not for OAuth flows.
 

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -37,6 +37,8 @@ const (
 	ApiTokenContextKey contextKey = "api_token_context_key"
 	// WorkerTeamCanonicalKey is the context key for the team canonical from a team-scoped worker JWT.
 	WorkerTeamCanonicalKey contextKey = "worker_team_canonical_key"
+	// WorkerSaltKey is the context key for the salt claim from a team-scoped worker JWT.
+	WorkerSaltKey contextKey = "worker_salt_key"
 )
 
 // publicFallbackRoutes lists routes that can fall back to public pipeline access
@@ -147,6 +149,9 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 									authFailed = true
 								} else if wtc, ok := claims["team_canonical"].(string); ok && wtc != "" {
 									rr = rr.WithContext(context.WithValue(rr.Context(), WorkerTeamCanonicalKey, wtc))
+									if salt, ok := claims["salt"].(string); ok && salt != "" {
+										rr = rr.WithContext(context.WithValue(rr.Context(), WorkerSaltKey, salt))
+									}
 								}
 							} else {
 								un, ok = userClaim["username"].(string)
@@ -217,7 +222,9 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 
 			// Some routes expose data that the blanket worker bypass below must
 			// not hand out unconditionally. A worker reaching one of those has
-			// to prove it holds a team-scoped token for the team in the path.
+			// to prove it holds a team-scoped token for the team in the path,
+			// and that token's salt claim must still match the team's current
+			// DB-stored salt so a regenerated (revoked) token stops working.
 			if isFromWorker && workerScopedRoutes[crn] {
 				vars := mux.Vars(rr)
 				tc := vars["team_canonical"]
@@ -230,6 +237,23 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 				if wtc != tc {
 					l.Error("worker token team mismatch", "route", crn.String(), "token_team", wtc, "requested_team", tc)
 					encodeError("Worker token is not scoped to this team", rw)
+					return
+				}
+				salt, _ := rr.Context().Value(WorkerSaltKey).(string)
+				if salt == "" {
+					l.Error("worker token missing salt claim", "route", crn.String())
+					encodeError("Worker token is missing its salt claim", rw)
+					return
+				}
+				valid, err := s.VerifyTeamWorkerTokenSalt(rr.Context(), tc, salt)
+				if err != nil {
+					l.Error("failed to verify worker token salt", "route", crn.String(), "error", err)
+					encodeError("Failed to verify worker token", rw)
+					return
+				}
+				if !valid {
+					l.Error("worker token salt mismatch or revoked", "route", crn.String())
+					encodeError("Worker token has been revoked", rw)
 					return
 				}
 				h.ServeHTTP(rw, rr)

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -37,8 +37,6 @@ const (
 	ApiTokenContextKey contextKey = "api_token_context_key"
 	// WorkerTeamCanonicalKey is the context key for the team canonical from a team-scoped worker JWT.
 	WorkerTeamCanonicalKey contextKey = "worker_team_canonical_key"
-	// WorkerSaltKey is the context key for the salt claim from a team-scoped worker JWT.
-	WorkerSaltKey contextKey = "worker_salt_key"
 )
 
 // publicFallbackRoutes lists routes that can fall back to public pipeline access
@@ -149,9 +147,6 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 									authFailed = true
 								} else if wtc, ok := claims["team_canonical"].(string); ok && wtc != "" {
 									rr = rr.WithContext(context.WithValue(rr.Context(), WorkerTeamCanonicalKey, wtc))
-									if salt, ok := claims["salt"].(string); ok && salt != "" {
-										rr = rr.WithContext(context.WithValue(rr.Context(), WorkerSaltKey, salt))
-									}
 								}
 							} else {
 								un, ok = userClaim["username"].(string)
@@ -239,7 +234,10 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 					encodeError("Worker token is not scoped to this team", rw)
 					return
 				}
-				salt, _ := rr.Context().Value(WorkerSaltKey).(string)
+				var salt string
+				if jwtClaims != nil {
+					salt, _ = jwtClaims["salt"].(string)
+				}
 				if salt == "" {
 					l.Error("worker token missing salt claim", "route", crn.String())
 					encodeError("Worker token is missing its salt claim", rw)


### PR DESCRIPTION
## Summary
- Check the worker token's salt claim on worker-scoped routes, closing the gap where rotating a team's worker token (the standard response to a leak) did not actually revoke HTTP access to `GetPipelineSecretValues`
- Refuse a secret value passed via `secrets set --value=...` (previously only the positional-argument path was guarded)
- Map a missing team/pipeline canonical to 404 instead of 500 when setting a secret
- Fix the interactive plain-value prompt truncating multi-word input (and reject an all-whitespace value, matching the old behavior)
- Dedupe the secret-name validation regex into the existing `validInputName`, and dedupe the scope-not-found error translation into one helper

Follow-up from a code review of #642 after it merged. #683 tracks the broader, out-of-scope gap this surfaced: worker token rotation only revokes access to secret values, not to other worker routes (build creation/updates, triggers, etc.), which has always been true and needs its own design pass.