### PR TITLE
ui: stop the mouse wheel zooming pipeline graphs, move Update above the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Graph zoom**: plain mouse wheel now scrolls the page over a pipeline graph; zoom with Ctrl/⌘+wheel, trackpad pinch, or the +/− buttons. Fullscreen still zooms on wheel.
+- **Pipeline editor**: the Update/Create button now sits above the graph preview instead of below it.
 - **Build list page load**: `GET /jobs/:name/builds` now omits the `steps` column for list views (returning only id, build_number, status, started_at, duration), reducing a typical 50-build response from ~16MB to ~50KB. Steps are fetched on-demand when a build tab is opened ([#652](https://github.com/PikoCI/pikoci/issues/652)).
 - **Pipeline image query**: `image.dot` now uses a lightweight query (`LatestBuildStatusByPipeline`) that selects only `id`, `build_number`, and `status`, cutting response time from 6-8s to under 1s ([#652](https://github.com/PikoCI/pikoci/issues/652)).
 

--- a/pikoci/transport/http/assets/js/app/components/Editor.js
+++ b/pikoci/transport/http/assets/js/app/components/Editor.js
@@ -739,6 +739,9 @@ export function Editor({ pipeline, teamCanonical, onSave, onSaveSuccess }) {
           <div class="piko-graph-bottom-body" id="graph-fullscreen" ref=${graphFsRef}></div>
         </div>
       </div>
+      <div class="mb-3">
+        <button type="submit" class="btn btn-primary">${isUpdate ? 'Update' : 'Create'}</button>
+      </div>
       <div class="piko-graph-strip" id="graph-strip">
         <div class="piko-graph-strip-header${graphStripOpen ? ' open' : ''}" id="graph-strip-header" onClick=${toggleGraphStrip}>
           <span><i class="bi bi-diagram-3"></i> Graph Preview</span>
@@ -747,7 +750,6 @@ export function Editor({ pipeline, teamCanonical, onSave, onSaveSuccess }) {
         <div class="piko-graph-strip-body" id="graph" ref=${graphRef}>
         </div>
       </div>
-      <button type="submit" class="btn btn-primary mt-2">${isUpdate ? 'Update' : 'Create'}</button>
     </form>
   `;
 }

--- a/pikoci/transport/http/assets/js/app/graph-zoom.js
+++ b/pikoci/transport/http/assets/js/app/graph-zoom.js
@@ -26,8 +26,8 @@ PikoGraphZoom.prototype = {
     var div = document.createElement('div');
     div.className = 'piko-graph-controls';
     div.innerHTML =
-      '<button type="button" title="Zoom in" data-action="zoomIn">+</button>' +
-      '<button type="button" title="Zoom out" data-action="zoomOut">&minus;</button>' +
+      '<button type="button" title="Zoom in (Ctrl+scroll)" data-action="zoomIn">+</button>' +
+      '<button type="button" title="Zoom out (Ctrl+scroll)" data-action="zoomOut">&minus;</button>' +
       '<button type="button" title="Reset" data-action="reset">&#x21BA;</button>' +
       '<button type="button" title="Fullscreen" data-action="fullscreen">&#x26F6;</button>';
     this.container.appendChild(div);
@@ -174,8 +174,12 @@ PikoGraphZoom.prototype = {
     this._applyViewBox();
   },
 
+  // A plain wheel scrolls the page; zooming needs Ctrl/Cmd (trackpad pinch
+  // arrives as a wheel event with ctrlKey set, so it keeps working). In the
+  // fullscreen overlay there is nothing to scroll, so the wheel zooms as-is.
   _onWheel: function(e) {
     if (!this.svg) return;
+    if (!this._fsOverlay && !e.ctrlKey && !e.metaKey) return;
     e.preventDefault();
     var factor = e.deltaY < 0 ? this.ZOOM_FACTOR : 1 / this.ZOOM_FACTOR;
     this.zoomAtPoint(e.clientX, e.clientY, factor);


### PR DESCRIPTION
## Problem

The graph zoom handler (`graph-zoom.js`) called `preventDefault()` on every wheel event over a pipeline SVG. With the cursor over a graph the page couldn't be scrolled — the wheel zoomed the diagram instead. This affects the pipeline page and both editor previews, which share `PikoGraphZoom`.

In the pipeline editor, the Update/Create button was the last element on the page, below the graph preview, so saving meant scrolling past the diagram.

## Changes

- **Wheel zoom**: a plain wheel now falls through to the browser and scrolls the page. Zoom with Ctrl/⌘+wheel — which is also what a trackpad pinch sends, so pinch keeps working — or the +/− buttons. The fullscreen overlay has nothing to scroll, so it still zooms on a plain wheel. Zoom button tooltips mention the shortcut.
- **Editor**: the Update/Create button moved from below the graph preview to between the editor card and the preview. Still inside the `<form>`, so submit and the fullscreen hide rule are unchanged.
- Two short entries under `Unreleased / Changed` in the changelog.

## Verified

Against a local in-memory server in a real browser:
- Pipeline page: plain wheel over the graph leaves the SVG `viewBox` untouched; Ctrl+wheel and ⌘+wheel both zoom at the cursor.
- Fullscreen: plain wheel still zooms; Esc closes.
- Editor with the preview expanded and a short viewport: wheeling over the graph scrolls the page, no zoom.
- Update button renders above the preview and submitting redirects back to the pipeline page.
