### PR TITLE
ui: serve static assets from a per-build path so browsers stop running stale JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Static asset caching**: the web UI's JS, CSS and images are now served from a per-build path (`/assets/<commit>/`) with a one-year immutable cache, and the page itself as `no-cache`. A browser picks up a new build on the next page load instead of running the previous build's modules from cache until the user empties it, which Safari in particular would do because the embedded assets carried no cache headers at all. The bare `/js/`, `/css/`, `/images/` and `/fonts/` paths still work and revalidate on every use.
 - **Build list page load**: `GET /jobs/:name/builds` now omits the `steps` column for list views (returning only id, build_number, status, started_at, duration), reducing a typical 50-build response from ~16MB to ~50KB. Steps are fetched on-demand when a build tab is opened ([#652](https://github.com/PikoCI/pikoci/issues/652)).
 - **Pipeline image query**: `image.dot` now uses a lightweight query (`LatestBuildStatusByPipeline`) that selects only `id`, `build_number`, and `status`, cutting response time from 6-8s to under 1s ([#652](https://github.com/PikoCI/pikoci/issues/652)).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.1 AS builder
 ARG TARGETOS TARGETARCH
+# .dockerignore keeps .git out of the context, so the git fallbacks below never
+# see a repository and the image reports "dev (unknown)". Pass the values in:
+#   --build-arg VERSION=$(git describe --tags --abbrev=0) --build-arg COMMIT=$(git rev-parse --short HEAD)
+# The commit also keys the web UI's asset cache-busting path.
+ARG VERSION COMMIT
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -ldflags "-X github.com/pikoci/pikoci/cmd.Version=$(git describe --tags --abbrev=0 2>/dev/null || echo dev) -X github.com/pikoci/pikoci/cmd.Commit=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+    go build -ldflags "-X github.com/pikoci/pikoci/cmd.Version=${VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo dev)} -X github.com/pikoci/pikoci/cmd.Commit=${COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}" \
     -o /pikoci .
 
 FROM alpine:3.21

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -80,7 +80,7 @@ var editCmd = &cobra.Command{
 		jwtSecret := []byte("local-edit-secret")
 		svc := pikoci.New(ctx, ur, tr, ppr, jr, rr, rt, br, rur, str, tgr, nil, nil, nil, nil, suow, jwtSecret, nil, logger)
 
-		handler := tshttp.LocalEditorHandler(svc, filePath, logger)
+		handler := tshttp.LocalEditorHandler(svc, filePath, logger, Commit)
 
 		listenAddr := fmt.Sprintf("127.0.0.1:%d", port)
 		listener, err := net.Listen("tcp", listenAddr)

--- a/pikoci/transport/http/assets_route.go
+++ b/pikoci/transport/http/assets_route.go
@@ -1,0 +1,60 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/pikoci/pikoci/pikoci/transport/http/assets"
+)
+
+// Static assets are served from an embed.FS, which carries no modification
+// times. http.FileServer therefore sends them with no Last-Modified, no ETag
+// and no Cache-Control, and a browser with no freshness information falls back
+// to its own heuristics. Safari's are the most generous: it keeps reusing a
+// cached module on ordinary navigation without asking the server, so after a
+// deploy it runs the previous build's JS until the user empties the cache.
+//
+// The fix is to make every build's assets live at a URL no earlier build ever
+// used. The whole tree is mounted under /assets/<build>/, and the page
+// references it from there; the module graph's relative imports resolve inside
+// the prefix on their own, so the JS files do not change. A URL that can never
+// mean anything else can be cached forever, hence immutable. The HTML that
+// points at the current prefix is the one thing that must always be re-read.
+//
+// The bare /js/, /css/, /images/ and /fonts/ routes stay for anything that
+// links them directly (the logo in the UI, older bookmarks); they revalidate on
+// every use rather than pinning a stale copy.
+
+// assetPrefix returns the versioned mount point for this build's assets, as a
+// path with leading and trailing slash. A binary built without ldflags has no
+// commit to key on, so a start timestamp stands in: the cache is then busted
+// on every restart, which is what a dev loop wants anyway.
+func assetPrefix(commit string) string {
+	if commit == "" || commit == "unknown" {
+		commit = strconv.FormatInt(time.Now().Unix(), 10)
+	}
+	return "/assets/" + commit + "/"
+}
+
+// mountAssets registers the embedded asset tree on r twice: immutable under
+// prefix, and revalidate-always at the bare top-level paths.
+func mountAssets(r *mux.Router, prefix string) {
+	fs := http.FileServer(http.FS(assets.Assets))
+
+	r.PathPrefix(prefix).Handler(http.StripPrefix(prefix, cacheControl("public, max-age=31536000, immutable", fs)))
+
+	legacy := cacheControl("no-cache", fs)
+	for _, p := range []string{"/css/", "/js/", "/images/", "/fonts/"} {
+		r.PathPrefix(p).Handler(legacy)
+	}
+}
+
+// cacheControl sets the Cache-Control header before delegating to next.
+func cacheControl(value string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", value)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pikoci/transport/http/assets_route_test.go
+++ b/pikoci/transport/http/assets_route_test.go
@@ -1,0 +1,104 @@
+package http
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pikoci/pikoci/pikoci/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestAssetPrefix(t *testing.T) {
+	assert.Equal(t, "/assets/abc1234/", assetPrefix("abc1234"))
+
+	// No commit to key on: still a usable prefix, and never the literal
+	// "unknown" that would be the same for every dev build.
+	for _, c := range []string{"", "unknown"} {
+		p := assetPrefix(c)
+		assert.True(t, strings.HasPrefix(p, "/assets/"), p)
+		assert.True(t, strings.HasSuffix(p, "/"), p)
+		assert.NotEqual(t, "/assets/unknown/", p)
+		assert.NotEqual(t, "/assets//", p)
+	}
+}
+
+func TestVersionedAssets(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+
+	handler := Handler(s, []byte("test-secret"), slog.Default(), nil, "", "test", "abc1234", "", nil)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	get := func(path string) (*http.Response, string) {
+		resp, err := http.Get(server.URL + path)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		resp.Body.Close()
+		return resp, string(body)
+	}
+
+	// The page names the build's prefix and is never served from cache
+	// without revalidation.
+	resp, body := get("/")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
+	assert.Contains(t, body, `src="/assets/abc1234/js/app/app.js"`)
+	assert.Contains(t, body, `"preact": "/assets/abc1234/js/vendor/preact.module.js"`)
+	assert.Contains(t, body, `href="/assets/abc1234/css/pikoci.css"`)
+	assert.NotContains(t, body, `"/js/`, "every asset reference must go through the prefix")
+	assert.NotContains(t, body, `"/css/`, "every asset reference must go through the prefix")
+
+	// Under the prefix the same file is immutable.
+	resp, body = get("/assets/abc1234/js/app/graph-zoom.js")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "public, max-age=31536000, immutable", resp.Header.Get("Cache-Control"))
+	assert.Contains(t, body, "PikoGraphZoom")
+
+	// A relative import from inside the prefix stays inside it.
+	resp, _ = get("/assets/abc1234/js/vendor/preact/hooks.module.js")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// The bare paths still work, but must be revalidated on every use.
+	resp, body = get("/js/app/graph-zoom.js")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
+	assert.Contains(t, body, "PikoGraphZoom")
+
+	// Anything else under the prefix is a plain 404, not the SPA page.
+	resp, _ = get("/assets/abc1234/js/app/no-such-file.js")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestLocalEditorVersionedAssets(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	s := mock.NewService(ctrl)
+
+	handler := LocalEditorHandler(s, "/nonexistent/pipeline.hcl", slog.Default(), "abc1234")
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/")
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
+	assert.Contains(t, string(body), `src="/assets/abc1234/js/app/local-app.js"`)
+	assert.NotContains(t, string(body), `"/js/`)
+
+	resp, err = http.Get(server.URL + "/assets/abc1234/js/app/local-app.js")
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "public, max-age=31536000, immutable", resp.Header.Get("Cache-Control"))
+}

--- a/pikoci/transport/http/handler.go
+++ b/pikoci/transport/http/handler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pikoci/pikoci/pikoci"
 	"github.com/pikoci/pikoci/pikoci/role"
-	"github.com/pikoci/pikoci/pikoci/transport/http/assets"
 	"github.com/pikoci/pikoci/pikoci/transport/http/templates"
 	"github.com/pikoci/pikoci/pikoci/user"
 )
@@ -460,18 +459,20 @@ func Handler(s pikoci.Service, ts []byte, l *slog.Logger, db *sql.DB, dbSystem, 
 	binApi.Methods(http.MethodGet).Path("/admin/export").Name(ExportDatabase.String()).Handler(exportDatabase(db, dbSystem))
 	binApi.Methods(http.MethodGet).Path("/teams/{team_canonical}/pipelines/{pipeline_canonical}/image{ext}").Name(GetPipelineImage.String()).Handler(getPipelineImage(s))
 
-	r.PathPrefix("/css/").Handler(http.FileServer(http.FS(assets.Assets)))
-	r.PathPrefix("/js/").Handler(http.FileServer(http.FS(assets.Assets)))
-	r.PathPrefix("/images/").Handler(http.FileServer(http.FS(assets.Assets)))
-	r.PathPrefix("/fonts/").Handler(http.FileServer(http.FS(assets.Assets)))
+	prefix := assetPrefix(commit)
+	mountAssets(r, prefix)
 
+	// The page is what names the current asset prefix, so it must never be
+	// served from cache without a trip to the server; see assets_route.go.
+	page := templates.PageData{AssetPrefix: prefix}
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t, ok := templates.Templates["views/layouts/index.tmpl"]
 		if !ok {
 			http.Error(w, "template not found", http.StatusInternalServerError)
 			return
 		}
-		if err := t.Execute(w, nil); err != nil {
+		w.Header().Set("Cache-Control", "no-cache")
+		if err := t.Execute(w, page); err != nil {
 			l.Error("failed to execute template", "error", err)
 		}
 	})

--- a/pikoci/transport/http/local.go
+++ b/pikoci/transport/http/local.go
@@ -1,23 +1,28 @@
 package http
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/gorilla/mux"
 	"github.com/pikoci/pikoci/pikoci"
-	"github.com/pikoci/pikoci/pikoci/transport/http/assets"
+	"github.com/pikoci/pikoci/pikoci/transport/http/templates"
 )
 
 // LocalEditorHandler creates an HTTP handler for the local pipeline editor.
 // It serves the editor UI pre-loaded with the HCL file at filePath,
 // provides graph preview via the existing createPipelineImage handler,
 // and writes changes back to disk on save.
-func LocalEditorHandler(s pikoci.Service, filePath string, l *slog.Logger) http.Handler {
+//
+// commit keys the versioned asset prefix, the same as the server; see
+// assets_route.go.
+func LocalEditorHandler(s pikoci.Service, filePath string, l *slog.Logger, commit string) http.Handler {
 	r := mux.NewRouter()
 
 	// API: load initial config
@@ -62,21 +67,25 @@ func LocalEditorHandler(s pikoci.Service, filePath string, l *slog.Logger) http.
 	r.Methods(http.MethodPost).Path("/teams/{team_canonical}/pipelines/image{ext}").Handler(createPipelineImage(s))
 
 	// Static assets
-	r.PathPrefix("/css/").Handler(http.FileServer(http.FS(assets.Assets)))
-	r.PathPrefix("/js/").Handler(http.FileServer(http.FS(assets.Assets)))
-	r.PathPrefix("/images/").Handler(http.FileServer(http.FS(assets.Assets)))
-	r.PathPrefix("/fonts/").Handler(http.FileServer(http.FS(assets.Assets)))
+	prefix := assetPrefix(commit)
+	mountAssets(r, prefix)
 
-	// Root: serve local editor HTML
+	// Root: serve local editor HTML. Rendered once; only the asset prefix
+	// varies, and it is fixed for the life of the process.
+	var page bytes.Buffer
+	if err := localEditorTemplate.Execute(&page, templates.PageData{AssetPrefix: prefix}); err != nil {
+		l.Error("failed to render local editor page", "error", err)
+	}
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write([]byte(localEditorHTML))
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Write(page.Bytes())
 	})
 
 	return r
 }
 
-const localEditorHTML = `<!DOCTYPE html>
+var localEditorTemplate = template.Must(template.New("local").Parse(`<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>PikoCI - Local Editor</title>
@@ -84,10 +93,10 @@ const localEditorHTML = `<!DOCTYPE html>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-    <link href="/css/bootstrap.min.css" rel="stylesheet" />
-    <link href="/css/pikoci.css" rel="stylesheet" />
-    <link href="/css/bootstrap-icons.min.css" rel="stylesheet" />
-    <link href="/images/favicon.svg" rel="icon" type="image/svg+xml"/>
+    <link href="{{.AssetPrefix}}css/bootstrap.min.css" rel="stylesheet" />
+    <link href="{{.AssetPrefix}}css/pikoci.css" rel="stylesheet" />
+    <link href="{{.AssetPrefix}}css/bootstrap-icons.min.css" rel="stylesheet" />
+    <link href="{{.AssetPrefix}}images/favicon.svg" rel="icon" type="image/svg+xml"/>
   </head>
   <body>
     <script>
@@ -101,22 +110,22 @@ const localEditorHTML = `<!DOCTYPE html>
     <script type="importmap">
     {
       "imports": {
-        "preact": "/js/vendor/preact.module.js",
-        "preact/": "/js/vendor/preact/",
-        "preact/hooks": "/js/vendor/preact/hooks.module.js",
-        "htm": "/js/vendor/htm.module.js",
-        "htm/preact": "/js/vendor/htm-preact.module.js",
-        "preact-router": "/js/vendor/preact-router.module.js",
-        "preact-router/match": "/js/vendor/preact-router-match.module.js",
-        "@preact/signals": "/js/vendor/signals.module.js",
-        "@preact/signals-core": "/js/vendor/signals-core.module.js"
+        "preact": "{{.AssetPrefix}}js/vendor/preact.module.js",
+        "preact/": "{{.AssetPrefix}}js/vendor/preact/",
+        "preact/hooks": "{{.AssetPrefix}}js/vendor/preact/hooks.module.js",
+        "htm": "{{.AssetPrefix}}js/vendor/htm.module.js",
+        "htm/preact": "{{.AssetPrefix}}js/vendor/htm-preact.module.js",
+        "preact-router": "{{.AssetPrefix}}js/vendor/preact-router.module.js",
+        "preact-router/match": "{{.AssetPrefix}}js/vendor/preact-router-match.module.js",
+        "@preact/signals": "{{.AssetPrefix}}js/vendor/signals.module.js",
+        "@preact/signals-core": "{{.AssetPrefix}}js/vendor/signals-core.module.js"
       }
     }
     </script>
 
-    <script type="text/javascript" src="/js/bootstrap.bundle.min.js"></script>
-    <script type="text/javascript" src="/js/viz-global.js"></script>
-    <script type="text/javascript" src="/js/codemirror-hcl.min.js"></script>
-    <script type="module" src="/js/app/local-app.js"></script>
+    <script type="text/javascript" src="{{.AssetPrefix}}js/bootstrap.bundle.min.js"></script>
+    <script type="text/javascript" src="{{.AssetPrefix}}js/viz-global.js"></script>
+    <script type="text/javascript" src="{{.AssetPrefix}}js/codemirror-hcl.min.js"></script>
+    <script type="module" src="{{.AssetPrefix}}js/app/local-app.js"></script>
   </body>
-</html>`
+</html>`))

--- a/pikoci/transport/http/templates/template.go
+++ b/pikoci/transport/http/templates/template.go
@@ -17,6 +17,15 @@ const (
 	extension = "/*.tmpl"
 )
 
+// PageData is what the layouts are executed with.
+type PageData struct {
+	// AssetPrefix is where this build's static files are mounted, with
+	// leading and trailing slash (e.g. "/assets/abc1234/"). Every asset URL
+	// in a layout is built from it, so a new build never resolves to a URL
+	// the browser has cached from an old one.
+	AssetPrefix string
+}
+
 var (
 	// layoutsDir is the directory containing layout template files.
 	layoutsDir = path.Join(viewsDir, "layouts")

--- a/pikoci/transport/http/templates/views/layouts/index.tmpl
+++ b/pikoci/transport/http/templates/views/layouts/index.tmpl
@@ -6,60 +6,60 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-    <link href="/css/bootstrap.min.css" rel="stylesheet" />
-    <link href="/css/pikoci.css" rel="stylesheet" />
-    <link href="/css/bootstrap-icons.min.css" rel="stylesheet" />
-    <link href="/images/favicon.svg" rel="icon" type="image/svg+xml"/>
+    <link href="{{.AssetPrefix}}css/bootstrap.min.css" rel="stylesheet" />
+    <link href="{{.AssetPrefix}}css/pikoci.css" rel="stylesheet" />
+    <link href="{{.AssetPrefix}}css/bootstrap-icons.min.css" rel="stylesheet" />
+    <link href="{{.AssetPrefix}}images/favicon.svg" rel="icon" type="image/svg+xml"/>
 
     <script type="importmap">
     {
       "imports": {
-        "preact": "/js/vendor/preact.module.js",
-        "preact/": "/js/vendor/preact/",
-        "preact/hooks": "/js/vendor/preact/hooks.module.js",
-        "htm": "/js/vendor/htm.module.js",
-        "htm/preact": "/js/vendor/htm-preact.module.js",
-        "preact-router": "/js/vendor/preact-router.module.js",
-        "preact-router/match": "/js/vendor/preact-router-match.module.js",
-        "@preact/signals": "/js/vendor/signals.module.js",
-        "@preact/signals-core": "/js/vendor/signals-core.module.js"
+        "preact": "{{.AssetPrefix}}js/vendor/preact.module.js",
+        "preact/": "{{.AssetPrefix}}js/vendor/preact/",
+        "preact/hooks": "{{.AssetPrefix}}js/vendor/preact/hooks.module.js",
+        "htm": "{{.AssetPrefix}}js/vendor/htm.module.js",
+        "htm/preact": "{{.AssetPrefix}}js/vendor/htm-preact.module.js",
+        "preact-router": "{{.AssetPrefix}}js/vendor/preact-router.module.js",
+        "preact-router/match": "{{.AssetPrefix}}js/vendor/preact-router-match.module.js",
+        "@preact/signals": "{{.AssetPrefix}}js/vendor/signals.module.js",
+        "@preact/signals-core": "{{.AssetPrefix}}js/vendor/signals-core.module.js"
       }
     }
     </script>
 
     <!-- Modulepreload hints: collapse 4 discovery rounds into 1 parallel fetch -->
     <!-- Vendor modules -->
-    <link rel="modulepreload" href="/js/vendor/preact.module.js" />
-    <link rel="modulepreload" href="/js/vendor/preact/hooks.module.js" />
-    <link rel="modulepreload" href="/js/vendor/htm.module.js" />
-    <link rel="modulepreload" href="/js/vendor/htm-preact.module.js" />
-    <link rel="modulepreload" href="/js/vendor/preact-router.module.js" />
-    <link rel="modulepreload" href="/js/vendor/preact-router-match.module.js" />
-    <link rel="modulepreload" href="/js/vendor/signals.module.js" />
-    <link rel="modulepreload" href="/js/vendor/signals-core.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/preact.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/preact/hooks.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/htm.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/htm-preact.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/preact-router.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/preact-router-match.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/signals.module.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/vendor/signals-core.module.js" />
     <!-- Core app modules -->
-    <link rel="modulepreload" href="/js/app/state.js" />
-    <link rel="modulepreload" href="/js/app/api.js" />
-    <link rel="modulepreload" href="/js/app/hooks.js" />
-    <link rel="modulepreload" href="/js/app/toast.js" />
-    <link rel="modulepreload" href="/js/app/utils.js" />
-    <link rel="modulepreload" href="/js/app/graph-zoom.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/state.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/api.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/hooks.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/toast.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/utils.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/graph-zoom.js" />
     <!-- Component modules -->
-    <link rel="modulepreload" href="/js/app/components/Layout.js" />
-    <link rel="modulepreload" href="/js/app/components/Login.js" />
-    <link rel="modulepreload" href="/js/app/components/Teams.js" />
-    <link rel="modulepreload" href="/js/app/components/PipelineList.js" />
-    <link rel="modulepreload" href="/js/app/components/PipelineShow.js" />
-    <link rel="modulepreload" href="/js/app/components/PipelineGraph.js" />
-    <link rel="modulepreload" href="/js/app/components/PipelineListView.js" />
-    <link rel="modulepreload" href="/js/app/components/Editor.js" />
-    <link rel="modulepreload" href="/js/app/components/Jobs.js" />
-    <link rel="modulepreload" href="/js/app/components/Resources.js" />
-    <link rel="modulepreload" href="/js/app/components/Workers.js" />
-    <link rel="modulepreload" href="/js/app/components/Users.js" />
-    <link rel="modulepreload" href="/js/app/components/OAuthCallback.js" />
-    <link rel="modulepreload" href="/js/app/components/OAuthCompleteProfile.js" />
-    <link rel="modulepreload" href="/js/app/components/OAuthAdmin.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Layout.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Login.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Teams.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/PipelineList.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/PipelineShow.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/PipelineGraph.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/PipelineListView.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Editor.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Jobs.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Resources.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Workers.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/Users.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/OAuthCallback.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/OAuthCompleteProfile.js" />
+    <link rel="modulepreload" href="{{.AssetPrefix}}js/app/components/OAuthAdmin.js" />
   </head>
   <body>
     <script>
@@ -70,9 +70,9 @@
 
     <div id="app"></div>
 
-    <script type="text/javascript" src="/js/bootstrap.bundle.min.js"></script>
-    <script type="text/javascript" src="/js/viz-global.js"></script>
-    <script type="text/javascript" src="/js/codemirror-hcl.min.js"></script>
-    <script type="module" src="/js/app/app.js"></script>
+    <script type="text/javascript" src="{{.AssetPrefix}}js/bootstrap.bundle.min.js"></script>
+    <script type="text/javascript" src="{{.AssetPrefix}}js/viz-global.js"></script>
+    <script type="text/javascript" src="{{.AssetPrefix}}js/codemirror-hcl.min.js"></script>
+    <script type="module" src="{{.AssetPrefix}}js/app/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

The web UI's JS, CSS and images are served from an `embed.FS`, which has no modification times, so `http.FileServer` sends them with **no `Last-Modified`, no `ETag` and no `Cache-Control`**. A browser with no freshness information falls back to its own heuristics. Safari's are the most generous: it keeps reusing a cached module on ordinary navigation without asking the server, so after a deploy it runs the previous build's JS until the user empties the cache. Chrome only avoids this by refetching everything on each reload.

We hit this deploying #691: the server was serving the fixed `graph-zoom.js`, Safari kept running the old one.

## Change

- Mount the asset tree under `/assets/<commit>/` (`assets_route.go`) with `Cache-Control: public, max-age=31536000, immutable`. A URL that can never mean another build can be cached forever.
- `index.tmpl` takes an `AssetPrefix` and builds every asset URL — stylesheets, favicon, the import map, the `modulepreload` hints, the scripts — from it. The module graph's own imports are all relative, so they resolve inside the prefix on their own; **no JS file changes**.
- The page is served `Cache-Control: no-cache`, so the one document that names the current prefix is always revalidated.
- A binary built without ldflags has no commit, so the start time stands in and a dev restart busts the cache too.
- The bare `/js/`, `/css/`, `/images/`, `/fonts/` routes stay for anything that links them directly (the logo, external links) and now send `no-cache`.
- `pikoci edit`'s local editor takes the commit and does the same.

Tests cover the prefix derivation, the headers on both mounts, that the page references only prefixed URLs, and that a relative import from inside the prefix stays inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gAD4kb83u59dor8ycrd2P